### PR TITLE
feat: Add comprehensive schema validation tests

### DIFF
--- a/tests_v2/test_common.py
+++ b/tests_v2/test_common.py
@@ -1,0 +1,125 @@
+"""Tests for common types and enums."""
+
+from research_system.schemas.common import (
+    ConfidenceLevel,
+    EntryStatus,
+    EntryType,
+    PositionSizingMethod,
+    RebalanceFrequency,
+    SignalType,
+    StrategyTier,
+    UniverseType,
+    ValidationStatus,
+)
+
+
+class TestEntryStatus:
+    """Tests for EntryStatus enum."""
+
+    def test_all_status_values_exist(self):
+        """Verify all expected status values are defined."""
+        expected = {"UNTESTED", "VALIDATED", "INVALIDATED", "BLOCKED", "ARCHIVED"}
+        actual = {s.value for s in EntryStatus}
+        assert actual == expected
+
+    def test_status_is_string_enum(self):
+        """Verify status values can be used as strings."""
+        assert EntryStatus.VALIDATED.value == "VALIDATED"
+        # str() on StrEnum includes class name, use .value for raw string
+        assert EntryStatus.VALIDATED == "VALIDATED"  # StrEnum comparison works
+
+
+class TestEntryType:
+    """Tests for EntryType enum."""
+
+    def test_all_entry_types_exist(self):
+        """Verify all expected entry types are defined."""
+        expected = {"STRAT", "IDEA", "IND", "TOOL", "LEARN", "DATA", "OBS"}
+        actual = {t.value for t in EntryType}
+        assert actual == expected
+
+    def test_entry_type_is_string_enum(self):
+        """Verify entry types can be used as strings."""
+        assert EntryType.STRAT.value == "STRAT"
+        assert EntryType.IDEA == "IDEA"  # StrEnum comparison works
+
+
+class TestValidationStatus:
+    """Tests for ValidationStatus enum."""
+
+    def test_all_validation_statuses_exist(self):
+        """Verify all expected validation statuses are defined."""
+        expected = {"PASSED", "FAILED", "ERROR", "BLOCKED"}
+        actual = {s.value for s in ValidationStatus}
+        assert actual == expected
+
+
+class TestConfidenceLevel:
+    """Tests for ConfidenceLevel enum."""
+
+    def test_all_confidence_levels_exist(self):
+        """Verify all expected confidence levels are defined."""
+        expected = {"HIGH", "MEDIUM", "LOW"}
+        actual = {c.value for c in ConfidenceLevel}
+        assert actual == expected
+
+
+class TestStrategyTier:
+    """Tests for StrategyTier enum."""
+
+    def test_tier_values_are_integers(self):
+        """Verify tiers are integer values 1-3."""
+        assert StrategyTier.TIER_1.value == 1
+        assert StrategyTier.TIER_2.value == 2
+        assert StrategyTier.TIER_3.value == 3
+
+    def test_tier_count(self):
+        """Verify exactly 3 tiers exist."""
+        assert len(StrategyTier) == 3
+
+
+class TestRebalanceFrequency:
+    """Tests for RebalanceFrequency enum."""
+
+    def test_all_frequencies_exist(self):
+        """Verify all expected frequencies are defined."""
+        expected = {"daily", "weekly", "monthly", "quarterly"}
+        actual = {f.value for f in RebalanceFrequency}
+        assert actual == expected
+
+
+class TestPositionSizingMethod:
+    """Tests for PositionSizingMethod enum."""
+
+    def test_all_methods_exist(self):
+        """Verify all expected sizing methods are defined."""
+        expected = {"equal_weight", "risk_parity", "volatility_target", "kelly", "fixed"}
+        actual = {m.value for m in PositionSizingMethod}
+        assert actual == expected
+
+
+class TestSignalType:
+    """Tests for SignalType enum."""
+
+    def test_all_signal_types_exist(self):
+        """Verify all expected signal types are defined."""
+        expected = {
+            "relative_momentum",
+            "absolute_momentum",
+            "mean_reversion",
+            "trend_following",
+            "breakout",
+            "custom",
+        }
+        actual = {s.value for s in SignalType}
+        assert actual == expected
+
+
+class TestUniverseType:
+    """Tests for UniverseType enum."""
+
+    def test_all_universe_types_exist(self):
+        """Verify all expected universe types are defined."""
+        expected = {"fixed", "dynamic", "sector", "index_constituents"}
+        actual = {u.value for u in UniverseType}
+        assert actual == expected

--- a/tests_v2/test_schemas.py
+++ b/tests_v2/test_schemas.py
@@ -1,15 +1,34 @@
-"""Basic tests for v2 schemas."""
+"""Comprehensive tests for v2 schemas."""
 
-from research_system.schemas.proposal import Proposal, ProposalRationale, ProposalType
+import pytest
+from pydantic import ValidationError
+
+from research_system.schemas.proposal import (
+    Proposal,
+    ProposalRationale,
+    ProposalStatus,
+    ProposalType,
+)
 from research_system.schemas.regime import (
+    CapLeadership,
     MarketDirection,
     RateEnvironment,
+    RegimeDefinition,
+    RegimePerformanceEntry,
+    RegimePerformanceSummary,
     RegimeTags,
+    SectorLeadership,
     VolatilityLevel,
 )
 from research_system.schemas.strategy import (
+    AllocationRule,
+    DataRequirement,
+    DerivedSignal,
+    FilterConfig,
     PositionSizingConfig,
     RebalanceConfig,
+    RegimeFilterConfig,
+    RiskManagementConfig,
     SignalConfig,
     StrategyDefinition,
     StrategyMetadata,
@@ -36,6 +55,57 @@ class TestStrategyDefinition:
         assert strategy.tier == 1
         assert len(strategy.universe.symbols) == 3
 
+    def test_tier2_strategy_with_expressions(self):
+        """Test creating a Tier 2 strategy with derived signals."""
+        strategy = StrategyDefinition(
+            tier=2,
+            metadata=StrategyMetadata(id="STRAT-002", name="Macro Rotation"),
+            strategy_type="macro_rotation",
+            universe=UniverseConfig(type="fixed", symbols=["SPY", "TLT", "GLD", "UUP"]),
+            position_sizing=PositionSizingConfig(method="risk_parity"),
+            rebalance=RebalanceConfig(frequency="monthly"),
+            data_requirements=[
+                DataRequirement(id="vix", source="yahoo", series="^VIX"),
+                DataRequirement(id="dxy", source="fred", series="DTWEXBGS"),
+            ],
+            derived_signals=[
+                DerivedSignal(id="risk_on", expression="vix < 20 and spy_momentum > 0"),
+            ],
+            allocation_rules=[
+                AllocationRule(
+                    name="risk_on_allocation",
+                    condition="risk_on == true",
+                    allocation={"SPY": 0.6, "GLD": 0.2, "TLT": 0.2},
+                ),
+                AllocationRule(
+                    name="risk_off_allocation",
+                    condition="risk_on == false",
+                    allocation={"TLT": 0.6, "GLD": 0.3, "UUP": 0.1},
+                ),
+            ],
+        )
+
+        assert strategy.tier == 2
+        assert len(strategy.data_requirements) == 2
+        assert len(strategy.derived_signals) == 1
+        assert len(strategy.allocation_rules) == 2
+
+    def test_tier3_strategy_requires_review(self):
+        """Test that Tier 3 strategies are marked for review."""
+        strategy = StrategyDefinition(
+            tier=3,
+            metadata=StrategyMetadata(id="STRAT-003", name="Custom ML Strategy"),
+            strategy_type="custom_ml",
+            universe=UniverseConfig(type="dynamic"),
+            position_sizing=PositionSizingConfig(method="volatility_target"),
+            rebalance=RebalanceConfig(frequency="daily"),
+            custom_code="# Custom backtesting code here",
+        )
+
+        assert strategy.tier == 3
+        assert strategy.review_required is True
+        assert strategy.custom_code is not None
+
     def test_strategy_hash_is_deterministic(self):
         """Test that the same strategy produces the same hash."""
         strategy1 = StrategyDefinition(
@@ -58,6 +128,51 @@ class TestStrategyDefinition:
 
         assert strategy1.compute_hash() == strategy2.compute_hash()
 
+    def test_strategy_hash_changes_with_content(self):
+        """Test that different strategies produce different hashes."""
+        strategy1 = StrategyDefinition(
+            tier=1,
+            metadata=StrategyMetadata(id="STRAT-001", name="Test"),
+            strategy_type="momentum",
+            universe=UniverseConfig(type="fixed", symbols=["SPY"]),
+            position_sizing=PositionSizingConfig(method="equal_weight"),
+            rebalance=RebalanceConfig(frequency="monthly"),
+        )
+
+        strategy2 = StrategyDefinition(
+            tier=1,
+            metadata=StrategyMetadata(id="STRAT-001", name="Test"),
+            strategy_type="momentum",
+            universe=UniverseConfig(type="fixed", symbols=["SPY", "TLT"]),  # Different
+            position_sizing=PositionSizingConfig(method="equal_weight"),
+            rebalance=RebalanceConfig(frequency="monthly"),
+        )
+
+        assert strategy1.compute_hash() != strategy2.compute_hash()
+
+    def test_strategy_hash_ignores_metadata_changes(self):
+        """Test that hash doesn't change when only metadata changes."""
+        strategy1 = StrategyDefinition(
+            tier=1,
+            metadata=StrategyMetadata(id="STRAT-001", name="Original Name"),
+            strategy_type="momentum",
+            universe=UniverseConfig(type="fixed", symbols=["SPY"]),
+            position_sizing=PositionSizingConfig(method="equal_weight"),
+            rebalance=RebalanceConfig(frequency="monthly"),
+        )
+
+        strategy2 = StrategyDefinition(
+            tier=1,
+            metadata=StrategyMetadata(id="STRAT-002", name="Different Name"),  # Different ID/name
+            strategy_type="momentum",
+            universe=UniverseConfig(type="fixed", symbols=["SPY"]),
+            position_sizing=PositionSizingConfig(method="equal_weight"),
+            rebalance=RebalanceConfig(frequency="monthly"),
+        )
+
+        # Hash should be the same since strategy logic is identical
+        assert strategy1.compute_hash() == strategy2.compute_hash()
+
     def test_strategy_json_serialization(self):
         """Test JSON serialization round-trip."""
         strategy = StrategyDefinition(
@@ -74,6 +189,129 @@ class TestStrategyDefinition:
 
         assert restored.metadata.id == strategy.metadata.id
         assert restored.strategy_type == strategy.strategy_type
+
+    def test_strategy_with_risk_management(self):
+        """Test strategy with risk management config."""
+        strategy = StrategyDefinition(
+            tier=1,
+            metadata=StrategyMetadata(id="STRAT-001", name="Risk Managed"),
+            strategy_type="momentum",
+            universe=UniverseConfig(
+                type="fixed",
+                symbols=["SPY", "QQQ"],
+                defensive_symbols=["TLT", "GLD"],
+            ),
+            signal=SignalConfig(type="trend_following", lookback_days=200),
+            position_sizing=PositionSizingConfig(method="equal_weight"),
+            rebalance=RebalanceConfig(frequency="weekly"),
+            risk_management=RiskManagementConfig(
+                regime_filter=RegimeFilterConfig(
+                    enabled=True,
+                    indicator="SPY_SMA_200",
+                    threshold=0.0,
+                    action="switch_to_defensive",
+                ),
+                stop_loss=0.10,
+                max_drawdown=0.20,
+            ),
+        )
+
+        assert strategy.risk_management is not None
+        assert strategy.risk_management.stop_loss == 0.10
+        assert strategy.risk_management.regime_filter.enabled is True
+
+    def test_strategy_with_filters(self):
+        """Test strategy with filter configs."""
+        strategy = StrategyDefinition(
+            tier=1,
+            metadata=StrategyMetadata(id="STRAT-001", name="Filtered"),
+            strategy_type="momentum",
+            universe=UniverseConfig(type="index_constituents", index="SPY"),
+            signal=SignalConfig(type="relative_momentum", lookback_days=126),
+            position_sizing=PositionSizingConfig(method="equal_weight"),
+            rebalance=RebalanceConfig(frequency="monthly"),
+            filters=[
+                FilterConfig(type="price", condition="above_sma", lookback_days=200),
+                FilterConfig(type="volume", condition="min_avg", threshold=1000000),
+            ],
+        )
+
+        assert len(strategy.filters) == 2
+        assert strategy.filters[0].type == "price"
+
+    def test_invalid_tier_rejected(self):
+        """Test that invalid tier values are rejected."""
+        with pytest.raises(ValidationError):
+            StrategyDefinition(
+                tier=4,  # Invalid - only 1, 2, 3 allowed
+                metadata=StrategyMetadata(id="STRAT-001", name="Test"),
+                strategy_type="momentum",
+                universe=UniverseConfig(type="fixed", symbols=["SPY"]),
+                position_sizing=PositionSizingConfig(method="equal_weight"),
+                rebalance=RebalanceConfig(frequency="monthly"),
+            )
+
+
+class TestUniverseConfig:
+    """Tests for UniverseConfig schema."""
+
+    def test_fixed_universe(self):
+        """Test fixed symbol universe."""
+        universe = UniverseConfig(type="fixed", symbols=["SPY", "TLT", "GLD"])
+        assert universe.type == "fixed"
+        assert len(universe.symbols) == 3
+
+    def test_index_constituents_universe(self):
+        """Test index-based universe."""
+        universe = UniverseConfig(type="index_constituents", index="SPY")
+        assert universe.type == "index_constituents"
+        assert universe.index == "SPY"
+
+    def test_sector_universe(self):
+        """Test sector-filtered universe."""
+        universe = UniverseConfig(
+            type="sector",
+            sector="technology",
+            min_market_cap=10_000_000_000,
+            min_volume=1_000_000,
+        )
+        assert universe.type == "sector"
+        assert universe.min_market_cap == 10_000_000_000
+
+
+class TestPositionSizingConfig:
+    """Tests for PositionSizingConfig schema."""
+
+    def test_equal_weight(self):
+        """Test equal weight sizing."""
+        sizing = PositionSizingConfig(method="equal_weight")
+        assert sizing.method == "equal_weight"
+        assert sizing.leverage == 1.0
+
+    def test_volatility_target(self):
+        """Test volatility target sizing."""
+        sizing = PositionSizingConfig(
+            method="volatility_target",
+            target_volatility=0.15,
+            max_position_size=0.25,
+        )
+        assert sizing.method == "volatility_target"
+        assert sizing.target_volatility == 0.15
+
+    def test_leverage_constraint(self):
+        """Test that leverage must be non-negative."""
+        with pytest.raises(ValidationError):
+            PositionSizingConfig(method="equal_weight", leverage=-1.0)
+
+    def test_max_position_size_bounds(self):
+        """Test max_position_size must be between 0 and 1."""
+        # Valid
+        sizing = PositionSizingConfig(method="equal_weight", max_position_size=0.5)
+        assert sizing.max_position_size == 0.5
+
+        # Invalid - above 1
+        with pytest.raises(ValidationError):
+            PositionSizingConfig(method="equal_weight", max_position_size=1.5)
 
 
 class TestRegimeTags:
@@ -104,6 +342,82 @@ class TestRegimeTags:
         assert result["volatility"] == "high"
         assert result["rate_environment"] == "rising"
 
+    def test_regime_tags_with_optional_fields(self):
+        """Test regime tags with optional sector and cap leadership."""
+        tags = RegimeTags(
+            direction=MarketDirection.BULL,
+            volatility=VolatilityLevel.LOW,
+            rate_environment=RateEnvironment.FLAT,
+            sector_leader=SectorLeadership.TECH,
+            cap_leadership=CapLeadership.LARGE,
+        )
+
+        result = tags.to_dict()
+        assert result["sector_leader"] == "tech"
+        assert result["cap_leadership"] == "large"
+
+    def test_regime_tags_without_optional_fields(self):
+        """Test to_dict excludes None optional fields."""
+        tags = RegimeTags(
+            direction=MarketDirection.SIDEWAYS,
+            volatility=VolatilityLevel.NORMAL,
+            rate_environment=RateEnvironment.FLAT,
+        )
+
+        result = tags.to_dict()
+        assert "sector_leader" not in result
+        assert "cap_leadership" not in result
+
+
+class TestRegimeDefinition:
+    """Tests for RegimeDefinition schema."""
+
+    def test_default_thresholds(self):
+        """Test default threshold values."""
+        definition = RegimeDefinition()
+
+        assert definition.direction_bull_threshold == 0.05
+        assert definition.direction_bear_threshold == -0.05
+        assert definition.volatility_low_threshold == 15.0
+        assert definition.volatility_high_threshold == 25.0
+
+    def test_custom_thresholds(self):
+        """Test custom threshold values."""
+        definition = RegimeDefinition(
+            direction_bull_threshold=0.10,
+            volatility_high_threshold=30.0,
+        )
+
+        assert definition.direction_bull_threshold == 0.10
+        assert definition.volatility_high_threshold == 30.0
+
+
+class TestRegimePerformance:
+    """Tests for regime performance schemas."""
+
+    def test_performance_entry(self):
+        """Test RegimePerformanceEntry."""
+        entry = RegimePerformanceEntry(
+            mean_sharpe=1.2,
+            mean_cagr=0.15,
+            n_windows=5,
+            win_rate=0.6,
+        )
+        assert entry.mean_sharpe == 1.2
+        assert entry.n_windows == 5
+
+    def test_performance_summary(self):
+        """Test RegimePerformanceSummary."""
+        summary = RegimePerformanceSummary(
+            by_direction={
+                "bull": RegimePerformanceEntry(mean_sharpe=1.5, mean_cagr=0.20, n_windows=8),
+                "bear": RegimePerformanceEntry(mean_sharpe=0.3, mean_cagr=0.02, n_windows=4),
+            },
+        )
+
+        assert "bull" in summary.by_direction
+        assert summary.by_direction["bull"].mean_sharpe == 1.5
+
 
 class TestProposal:
     """Tests for Proposal schema."""
@@ -124,4 +438,66 @@ class TestProposal:
 
         assert proposal.id == "PROP-001"
         assert proposal.type == ProposalType.ENHANCEMENT_LEVERAGE
-        assert proposal.status.value == "pending"
+        assert proposal.status == ProposalStatus.PENDING
+
+    def test_proposal_types(self):
+        """Test all proposal types can be used."""
+        types = [
+            ProposalType.ENHANCEMENT_LEVERAGE,
+            ProposalType.ENHANCEMENT_SIZING,
+            ProposalType.COMPOSITE_STRATEGY,
+            ProposalType.NEW_STRATEGY,
+        ]
+
+        for ptype in types:
+            proposal = Proposal(
+                id=f"PROP-{ptype.value}",
+                type=ptype,
+                created_by="test",
+                title="Test",
+                description="Test",
+                rationale=ProposalRationale(
+                    proposed_solution="Solution",
+                    expected_improvement="Improvement",
+                ),
+            )
+            assert proposal.type == ptype
+
+    def test_proposal_with_component_strategies(self):
+        """Test composite proposal with component strategies."""
+        proposal = Proposal(
+            id="PROP-001",
+            type=ProposalType.COMPOSITE_STRATEGY,
+            created_by="synthesis_engine",
+            title="Combine Strategies",
+            description="Combine momentum and mean reversion",
+            component_strategies=["STRAT-001", "STRAT-002"],
+            rationale=ProposalRationale(
+                proposed_solution="50/50 allocation",
+                expected_improvement="Diversification benefit",
+            ),
+        )
+
+        assert len(proposal.component_strategies) == 2
+        assert "STRAT-001" in proposal.component_strategies
+
+    def test_proposal_json_roundtrip(self):
+        """Test JSON serialization round-trip."""
+        proposal = Proposal(
+            id="PROP-001",
+            type=ProposalType.ENHANCEMENT_SIZING,
+            created_by="test",
+            title="Adjust Position Sizing",
+            description="Implement volatility targeting",
+            rationale=ProposalRationale(
+                proposed_solution="Use volatility-scaled positions",
+                expected_improvement="Reduce drawdowns",
+            ),
+        )
+
+        json_str = proposal.model_dump_json()
+        restored = Proposal.model_validate_json(json_str)
+
+        assert restored.id == proposal.id
+        assert restored.type == proposal.type
+        assert restored.rationale.proposed_solution == proposal.rationale.proposed_solution

--- a/tests_v2/test_validation.py
+++ b/tests_v2/test_validation.py
@@ -1,0 +1,312 @@
+"""Tests for validation result schemas."""
+
+import pytest
+from pydantic import ValidationError
+
+from research_system.schemas.common import ConfidenceLevel, ValidationStatus
+from research_system.schemas.regime import (
+    MarketDirection,
+    RateEnvironment,
+    RegimePerformanceSummary,
+    RegimeTags,
+    VolatilityLevel,
+)
+from research_system.schemas.validation import (
+    AggregateMetrics,
+    PerformanceFingerprint,
+    ValidationResult,
+    WindowMetrics,
+    WindowResult,
+)
+
+
+class TestWindowMetrics:
+    """Tests for WindowMetrics schema."""
+
+    def test_required_fields(self):
+        """Test that required fields must be provided."""
+        # Should work with required fields
+        metrics = WindowMetrics(cagr=0.15, sharpe=1.2, max_drawdown=0.12)
+        assert metrics.cagr == 0.15
+        assert metrics.sharpe == 1.2
+        assert metrics.max_drawdown == 0.12
+
+    def test_optional_fields_default_to_none(self):
+        """Test that optional fields default to None."""
+        metrics = WindowMetrics(cagr=0.15, sharpe=1.2, max_drawdown=0.12)
+        assert metrics.sortino is None
+        assert metrics.win_rate is None
+        assert metrics.profit_factor is None
+        assert metrics.trades is None
+        assert metrics.volatility is None
+
+    def test_all_fields_populated(self):
+        """Test creating metrics with all fields."""
+        metrics = WindowMetrics(
+            cagr=0.15,
+            sharpe=1.2,
+            sortino=1.5,
+            max_drawdown=0.12,
+            win_rate=0.55,
+            profit_factor=1.8,
+            trades=42,
+            volatility=0.18,
+        )
+        assert metrics.sortino == 1.5
+        assert metrics.trades == 42
+
+
+class TestWindowResult:
+    """Tests for WindowResult schema."""
+
+    def test_window_result_creation(self):
+        """Test creating a window result."""
+        result = WindowResult(
+            window_id=1,
+            start_date="2020-01-01",
+            end_date="2020-12-31",
+            metrics=WindowMetrics(cagr=0.15, sharpe=1.2, max_drawdown=0.12),
+            regime_tags=RegimeTags(
+                direction=MarketDirection.BULL,
+                volatility=VolatilityLevel.NORMAL,
+                rate_environment=RateEnvironment.FALLING,
+            ),
+        )
+        assert result.window_id == 1
+        assert result.start_date == "2020-01-01"
+        assert result.metrics.cagr == 0.15
+
+    def test_window_result_with_benchmark(self):
+        """Test window result includes benchmark data."""
+        result = WindowResult(
+            window_id=1,
+            start_date="2020-01-01",
+            end_date="2020-12-31",
+            metrics=WindowMetrics(cagr=0.15, sharpe=1.2, max_drawdown=0.12),
+            regime_tags=RegimeTags(
+                direction=MarketDirection.BULL,
+                volatility=VolatilityLevel.NORMAL,
+                rate_environment=RateEnvironment.FALLING,
+            ),
+            benchmark_cagr=0.10,
+            benchmark_sharpe=0.8,
+        )
+        assert result.benchmark_cagr == 0.10
+        assert result.benchmark_sharpe == 0.8
+
+
+class TestAggregateMetrics:
+    """Tests for AggregateMetrics schema."""
+
+    def test_aggregate_metrics_creation(self):
+        """Test creating aggregate metrics."""
+        metrics = AggregateMetrics(
+            mean_sharpe=1.1,
+            sharpe_std=0.3,
+            sharpe_95_ci_low=0.5,
+            sharpe_95_ci_high=1.7,
+            mean_cagr=0.12,
+            cagr_std=0.05,
+            mean_max_drawdown=0.15,
+            worst_drawdown=0.25,
+            consistency_score=0.75,
+            p_value=0.03,
+            p_value_adjusted=0.05,
+        )
+        assert metrics.mean_sharpe == 1.1
+        assert metrics.consistency_score == 0.75
+
+    def test_consistency_score_bounds(self):
+        """Test that consistency_score must be between 0 and 1."""
+        # Valid boundary values
+        metrics = AggregateMetrics(
+            mean_sharpe=1.0,
+            sharpe_std=0.3,
+            sharpe_95_ci_low=0.5,
+            sharpe_95_ci_high=1.5,
+            mean_cagr=0.1,
+            cagr_std=0.05,
+            mean_max_drawdown=0.1,
+            worst_drawdown=0.2,
+            consistency_score=0.0,  # Minimum valid
+            p_value=0.05,
+            p_value_adjusted=0.05,
+        )
+        assert metrics.consistency_score == 0.0
+
+        metrics = AggregateMetrics(
+            mean_sharpe=1.0,
+            sharpe_std=0.3,
+            sharpe_95_ci_low=0.5,
+            sharpe_95_ci_high=1.5,
+            mean_cagr=0.1,
+            cagr_std=0.05,
+            mean_max_drawdown=0.1,
+            worst_drawdown=0.2,
+            consistency_score=1.0,  # Maximum valid
+            p_value=0.05,
+            p_value_adjusted=0.05,
+        )
+        assert metrics.consistency_score == 1.0
+
+    def test_consistency_score_invalid_bounds(self):
+        """Test that invalid consistency_score raises error."""
+        with pytest.raises(ValidationError):
+            AggregateMetrics(
+                mean_sharpe=1.0,
+                sharpe_std=0.3,
+                sharpe_95_ci_low=0.5,
+                sharpe_95_ci_high=1.5,
+                mean_cagr=0.1,
+                cagr_std=0.05,
+                mean_max_drawdown=0.1,
+                worst_drawdown=0.2,
+                consistency_score=1.5,  # Invalid - above 1
+                p_value=0.05,
+                p_value_adjusted=0.05,
+            )
+
+
+class TestPerformanceFingerprint:
+    """Tests for PerformanceFingerprint schema."""
+
+    def test_fingerprint_creation(self):
+        """Test creating a performance fingerprint."""
+        fingerprint = PerformanceFingerprint(
+            best_regimes=["bull_low_vol", "sideways_normal"],
+            worst_regimes=["bear_high_vol"],
+            untested_regimes=["bear_low_vol"],
+            recommended_use="Use in trending markets with moderate volatility",
+            avoid_when="High volatility bear markets",
+        )
+        assert len(fingerprint.best_regimes) == 2
+        assert "bull_low_vol" in fingerprint.best_regimes
+
+    def test_fingerprint_minimal(self):
+        """Test fingerprint with only required fields."""
+        fingerprint = PerformanceFingerprint(
+            recommended_use="General purpose momentum strategy",
+        )
+        assert fingerprint.best_regimes == []
+        assert fingerprint.avoid_when is None
+
+
+class TestValidationResult:
+    """Tests for ValidationResult schema."""
+
+    def _create_valid_result(self, **overrides):
+        """Helper to create a valid ValidationResult."""
+        defaults = {
+            "strategy_id": "STRAT-001",
+            "strategy_definition_hash": "sha256:abc123",
+            "generated_code_hash": "sha256:def456",
+            "walk_forward_results": [
+                WindowResult(
+                    window_id=1,
+                    start_date="2020-01-01",
+                    end_date="2020-12-31",
+                    metrics=WindowMetrics(cagr=0.15, sharpe=1.2, max_drawdown=0.12),
+                    regime_tags=RegimeTags(
+                        direction=MarketDirection.BULL,
+                        volatility=VolatilityLevel.NORMAL,
+                        rate_environment=RateEnvironment.FALLING,
+                    ),
+                ),
+            ],
+            "aggregate_metrics": AggregateMetrics(
+                mean_sharpe=1.1,
+                sharpe_std=0.3,
+                sharpe_95_ci_low=0.5,
+                sharpe_95_ci_high=1.7,
+                mean_cagr=0.12,
+                cagr_std=0.05,
+                mean_max_drawdown=0.15,
+                worst_drawdown=0.25,
+                consistency_score=0.75,
+                p_value=0.03,
+                p_value_adjusted=0.05,
+            ),
+            "regime_performance": RegimePerformanceSummary(),
+            "performance_fingerprint": PerformanceFingerprint(
+                recommended_use="General use",
+            ),
+            "validation_status": ValidationStatus.PASSED,
+            "confidence": ConfidenceLevel.HIGH,
+        }
+        defaults.update(overrides)
+        return ValidationResult(**defaults)
+
+    def test_validation_result_creation(self):
+        """Test creating a full validation result."""
+        result = self._create_valid_result()
+        assert result.strategy_id == "STRAT-001"
+        assert result.validation_status == ValidationStatus.PASSED
+
+    def test_is_valid_method(self):
+        """Test is_valid() returns correct status."""
+        passed = self._create_valid_result(validation_status=ValidationStatus.PASSED)
+        assert passed.is_valid() is True
+
+        failed = self._create_valid_result(validation_status=ValidationStatus.FAILED)
+        assert failed.is_valid() is False
+
+        error = self._create_valid_result(validation_status=ValidationStatus.ERROR)
+        assert error.is_valid() is False
+
+    def test_meets_threshold_default(self):
+        """Test meets_threshold with default parameters."""
+        # Good strategy
+        good = self._create_valid_result()
+        assert good.meets_threshold() is True
+
+        # Bad sharpe
+        bad_sharpe = self._create_valid_result(
+            aggregate_metrics=AggregateMetrics(
+                mean_sharpe=0.3,  # Below 0.5 threshold
+                sharpe_std=0.3,
+                sharpe_95_ci_low=-0.1,
+                sharpe_95_ci_high=0.7,
+                mean_cagr=0.05,
+                cagr_std=0.05,
+                mean_max_drawdown=0.15,
+                worst_drawdown=0.25,
+                consistency_score=0.75,
+                p_value=0.03,
+                p_value_adjusted=0.05,
+            ),
+        )
+        assert bad_sharpe.meets_threshold() is False
+
+    def test_meets_threshold_custom(self):
+        """Test meets_threshold with custom parameters."""
+        result = self._create_valid_result()
+
+        # Should pass with lenient thresholds
+        assert result.meets_threshold(min_sharpe=0.5, min_consistency=0.5) is True
+
+        # Should fail with strict thresholds
+        assert result.meets_threshold(min_sharpe=2.0) is False
+
+    def test_walk_forward_requires_at_least_one_window(self):
+        """Test that at least one walk-forward window is required."""
+        with pytest.raises(ValidationError):
+            self._create_valid_result(walk_forward_results=[])
+
+    def test_validation_result_json_roundtrip(self):
+        """Test JSON serialization round-trip."""
+        result = self._create_valid_result()
+        json_str = result.model_dump_json()
+        restored = ValidationResult.model_validate_json(json_str)
+
+        assert restored.strategy_id == result.strategy_id
+        assert restored.validation_status == result.validation_status
+        assert restored.aggregate_metrics.mean_sharpe == result.aggregate_metrics.mean_sharpe
+
+    def test_blocked_result_with_reason(self):
+        """Test blocked result includes blocking reason."""
+        result = self._create_valid_result(
+            validation_status=ValidationStatus.BLOCKED,
+            blocking_reason="Insufficient historical data for validation",
+        )
+        assert result.validation_status == ValidationStatus.BLOCKED
+        assert "Insufficient" in result.blocking_reason


### PR DESCRIPTION
## Summary

Adds 58 comprehensive tests covering all v2 schemas:

- **test_common.py** (12 tests): Tests for all enum types
  - EntryStatus, EntryType, ValidationStatus, ConfidenceLevel
  - StrategyTier, RebalanceFrequency, PositionSizingMethod
  - SignalType, UniverseType

- **test_schemas.py** (28 tests): Strategy, regime, and proposal schemas
  - Tier 1, 2, 3 strategy creation and validation
  - Strategy hash determinism and content sensitivity
  - JSON serialization round-trips
  - Risk management and filter configurations
  - Regime tags and definitions
  - Proposal types and component strategies

- **test_validation.py** (18 tests): Validation result schemas
  - WindowMetrics required/optional fields
  - WindowResult with benchmarks
  - AggregateMetrics bounds validation
  - ValidationResult.is_valid() and meets_threshold()
  - JSON round-trip serialization

## Test plan

- [x] All 58 tests pass locally
- [x] ruff check passes
- [x] ruff format passes  
- [x] mypy passes
- [ ] CI workflow passes on GitHub Actions

Addresses #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)