### PR TITLE
fix: Extract content from LLMResponse before code extraction

### DIFF
--- a/research_system/codegen/v4_generator.py
+++ b/research_system/codegen/v4_generator.py
@@ -226,8 +226,8 @@ class V4CodeGenerator:
             prompt = self._build_llm_prompt(strategy)
             response = self.llm_client.generate(prompt)
 
-            # Extract code from response
-            code = self._extract_code_from_response(response)
+            # Extract code from response (response.content is the text)
+            code = self._extract_code_from_response(response.content)
             if not code:
                 return V4CodeGenResult(
                     success=False,


### PR DESCRIPTION
## Summary
- Fix TypeError in v4-run code generation: `expected string or bytes-like object, got 'LLMResponse'`
- Access `response.content` instead of passing full LLMResponse object to `_extract_code_from_response`

## Test plan
- [x] All 32 relevant tests pass (15 codegen + 17 runner)
- [ ] Manual test: `research v4-run STRAT-001` in user workspace

Fixes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)