### PR TITLE
fix: Require lean.json and pass --lean-config to avoid interactive prompt

### DIFF
--- a/research_system/validation/backtest.py
+++ b/research_system/validation/backtest.py
@@ -294,14 +294,21 @@ class BacktestExecutor:
         max_retries: int,
     ) -> BacktestResult | None:
         """Execute the backtest command and handle the result."""
+        # Check for lean.json config - required to avoid interactive prompts
+        lean_config = self.workspace_path / "lean.json"
+        if not lean_config.exists():
+            return BacktestResult(
+                success=False,
+                error=f"No lean.json found in workspace. Run 'lean init' in {self.workspace_path} first.",
+            )
+
         # Build command
         if self.use_local:
             cmd = ["lean", "backtest", str(project_dir), "--download-data"]
-            lean_config = self.workspace_path / "lean.json"
-            if lean_config.exists():
-                cmd.extend(["--lean-config", str(lean_config)])
+            cmd.extend(["--lean-config", str(lean_config)])
         else:
             cmd = ["lean", "cloud", "backtest", str(project_dir), "--push"]
+            cmd.extend(["--lean-config", str(lean_config)])
 
         logger.info(f"Running: {' '.join(cmd)}")
 


### PR DESCRIPTION
## Summary
- Check for lean.json in workspace before running backtest
- Return clear error if not found: "Run 'lean init' in {workspace} first"
- Always pass --lean-config flag for both local and cloud modes

## Test plan
- [x] All 33 tests pass (16 backtest + 17 runner)
- [ ] Manual test: `research v4-run STRAT-001` after running `lean init` in workspace

Fixes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)