### PR TITLE
fix: Remove --lean-config from cloud backtest command

### DIFF
--- a/research_system/validation/backtest.py
+++ b/research_system/validation/backtest.py
@@ -307,8 +307,8 @@ class BacktestExecutor:
             cmd = ["lean", "backtest", str(project_dir), "--download-data"]
             cmd.extend(["--lean-config", str(lean_config)])
         else:
+            # Note: lean cloud backtest doesn't support --lean-config flag
             cmd = ["lean", "cloud", "backtest", str(project_dir), "--push"]
-            cmd.extend(["--lean-config", str(lean_config)])
 
         logger.info(f"Running: {' '.join(cmd)}")
 


### PR DESCRIPTION
## Summary
- Remove `--lean-config` flag from `lean cloud backtest` (not supported)
- Keep lean.json check to ensure LEAN is initialized
- Local backtests still use `--lean-config`

## Test plan
- [x] All 33 tests pass
- [ ] Manual test: `research v4-run STRAT-001` (cloud mode)

Fixes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)