### PR TITLE
feat: Add options income template and LLM error correction loop

### DIFF
--- a/research_system/codegen/templates/v4/__init__.py
+++ b/research_system/codegen/templates/v4/__init__.py
@@ -5,6 +5,7 @@ Template Structure:
 - momentum.py.j2: Momentum/rotation strategies
 - mean_reversion.py.j2: Z-score based mean reversion
 - regime_adaptive.py.j2: Regime-switching strategies
+- options_income.py.j2: Options income strategies (puts, spreads, covered calls)
 
 Template Selection:
 Templates are selected based on the strategy's signal_type or strategy_type field.
@@ -33,6 +34,16 @@ V4_STRATEGY_TO_TEMPLATE = {
     "regime-adaptive": "regime_adaptive.py.j2",
     "regime_switching": "regime_adaptive.py.j2",
     "tactical_allocation": "regime_adaptive.py.j2",
+    # Options income strategies
+    "options_income": "options_income.py.j2",
+    "options-income": "options_income.py.j2",
+    "cash_secured_put": "options_income.py.j2",
+    "cash-secured-put": "options_income.py.j2",
+    "put_credit_spread": "options_income.py.j2",
+    "put-credit-spread": "options_income.py.j2",
+    "covered_call": "options_income.py.j2",
+    "covered-call": "options_income.py.j2",
+    "options": "options_income.py.j2",
     # Fallback
     "base": "base.py.j2",
 }

--- a/research_system/codegen/templates/v4/options_income.py.j2
+++ b/research_system/codegen/templates/v4/options_income.py.j2
@@ -1,0 +1,303 @@
+{# V4 Options Income Strategy Template #}
+{# Supports: cash_secured_put, put_credit_spread, covered_call #}
+# region imports
+from AlgorithmImports import *
+from datetime import timedelta
+# endregion
+
+
+class {{ class_name }}(QCAlgorithm):
+    """
+    {{ strategy.name }}
+
+    {{ strategy.description | default("V4 options income strategy.", true) }}
+
+    Strategy ID: {{ strategy.id }}
+    Type: Options Income ({{ strategy.parameters.sub_type | default("cash_secured_put", true) }})
+    Generated: {{ timestamp }}
+    """
+
+    def initialize(self):
+        """Initialize the options income strategy."""
+        self.set_cash({{ strategy.parameters.initial_capital | default(100000, true) }})
+
+        # Benchmark
+        self.set_benchmark("SPY")
+
+        # Underlying symbol
+        self._underlying_ticker = "{{ strategy.parameters.underlying | default('SPY', true) }}"
+
+        # Add underlying equity with RAW normalization (REQUIRED for options)
+        self._equity = self.add_equity(self._underlying_ticker, Resolution.MINUTE)
+        self._equity.set_data_normalization_mode(DataNormalizationMode.RAW)
+        self._underlying = self._equity.symbol
+
+        # Add options chain
+        option = self.add_option(self._underlying_ticker)
+        self._option_symbol = option.symbol
+
+        # Configure option filter with PascalCase methods
+        option.set_filter(lambda u: u
+            .IncludeWeeklys()
+            .Strikes(-{{ strategy.parameters.strike_range | default(10, true) }}, {{ strategy.parameters.strike_range | default(10, true) }})
+            .Expiration({{ strategy.parameters.min_dte | default(7, true) }}, {{ strategy.parameters.max_dte | default(45, true) }})
+        )
+
+        # Trading parameters
+        self._target_delta = {{ strategy.parameters.target_delta | default(0.30, true) }}
+        self._min_premium = {{ strategy.parameters.min_premium | default(0.50, true) }}
+        self._max_positions = {{ strategy.parameters.max_positions | default(1, true) }}
+        self._profit_target = {{ strategy.parameters.profit_target | default(0.50, true) }}  # Close at 50% profit
+        self._stop_loss = {{ strategy.parameters.stop_loss | default(2.0, true) }}  # Close at 200% loss
+
+{% if strategy.parameters.sub_type == 'put_credit_spread' %}
+        # Spread width for credit spreads
+        self._spread_width = {{ strategy.parameters.spread_width | default(5, true) }}
+{% endif %}
+
+{% if strategy.parameters.sub_type == 'covered_call' %}
+        # Shares to cover for covered calls
+        self._shares_per_contract = 100
+{% endif %}
+
+        # Track open positions
+        self._positions = {}
+
+        # Schedule trading
+        self.schedule.on(
+            self.date_rules.every_day(self._underlying_ticker),
+            self.time_rules.after_market_open(self._underlying_ticker, 30),
+            self.check_positions
+        )
+
+        # Schedule position management
+        self.schedule.on(
+            self.date_rules.every_day(self._underlying_ticker),
+            self.time_rules.before_market_close(self._underlying_ticker, 15),
+            self.manage_positions
+        )
+
+    def check_positions(self):
+        """Check and open new positions if needed."""
+        if self.is_warming_up:
+            return
+
+        # Count current option positions
+        current_positions = sum(1 for h in self.portfolio.values()
+                                if h.invested and h.symbol.security_type == SecurityType.OPTION)
+
+        if current_positions >= self._max_positions:
+            return
+
+{% if strategy.parameters.sub_type == 'cash_secured_put' %}
+        self._open_cash_secured_put()
+{% elif strategy.parameters.sub_type == 'put_credit_spread' %}
+        self._open_put_credit_spread()
+{% else %}
+        self._open_covered_call()
+{% endif %}
+
+    def manage_positions(self):
+        """Manage existing positions - profit taking and stop losses."""
+        if self.is_warming_up:
+            return
+
+        for symbol, holding in list(self.portfolio.items()):
+            if not holding.invested:
+                continue
+
+            if symbol.security_type != SecurityType.OPTION:
+                continue
+
+            # Check if position was opened by us (tracked)
+            entry_price = self._positions.get(symbol)
+            if entry_price is None:
+                continue
+
+            current_price = self.securities[symbol].price
+            if current_price <= 0:
+                continue
+
+            # For short options, profit when price drops
+            if holding.quantity < 0:
+                # Profit target: close at X% of entry premium
+                if current_price <= entry_price * (1 - self._profit_target):
+                    self.liquidate(symbol, "Profit target reached")
+                    del self._positions[symbol]
+                    self.log(f"Closed {symbol} for profit. Entry: {entry_price:.2f}, Exit: {current_price:.2f}")
+
+                # Stop loss: close if premium increased too much
+                elif current_price >= entry_price * (1 + self._stop_loss):
+                    self.liquidate(symbol, "Stop loss triggered")
+                    del self._positions[symbol]
+                    self.log(f"Closed {symbol} for loss. Entry: {entry_price:.2f}, Exit: {current_price:.2f}")
+
+{% if strategy.parameters.sub_type == 'cash_secured_put' %}
+    def _open_cash_secured_put(self):
+        """Open a cash-secured put position."""
+        chain = self.option_chain(self._option_symbol)
+        if not chain:
+            return
+
+        # Filter for puts
+        puts = [c for c in chain if c.right == OptionRight.PUT]
+        if not puts:
+            return
+
+        # Find put with target delta (OTM puts have negative delta)
+        target_put = None
+        best_delta_diff = float('inf')
+
+        for contract in puts:
+            # Skip if no greeks
+            if contract.greeks is None or contract.greeks.delta is None:
+                continue
+
+            delta = abs(contract.greeks.delta)
+            delta_diff = abs(delta - self._target_delta)
+
+            # Check minimum premium
+            if contract.bid_price < self._min_premium:
+                continue
+
+            if delta_diff < best_delta_diff:
+                best_delta_diff = delta_diff
+                target_put = contract
+
+        if target_put is None:
+            return
+
+        # Sell the put (negative quantity = short)
+        self.market_order(target_put.symbol, -1)
+        self._positions[target_put.symbol] = target_put.bid_price
+        self.log(f"Sold put: {target_put.symbol}, Strike: {target_put.strike}, "
+                 f"DTE: {(target_put.expiry - self.time).days}, Premium: {target_put.bid_price:.2f}")
+{% endif %}
+
+{% if strategy.parameters.sub_type == 'put_credit_spread' %}
+    def _open_put_credit_spread(self):
+        """Open a put credit spread (bull put spread)."""
+        chain = self.option_chain(self._option_symbol)
+        if not chain:
+            return
+
+        # Filter for puts with same expiry
+        puts = [c for c in chain if c.right == OptionRight.PUT]
+        if not puts:
+            return
+
+        # Group by expiry
+        by_expiry = {}
+        for put in puts:
+            if put.expiry not in by_expiry:
+                by_expiry[put.expiry] = []
+            by_expiry[put.expiry].append(put)
+
+        # Find best spread
+        best_spread = None
+        best_credit = 0
+
+        for expiry, contracts in by_expiry.items():
+            contracts = sorted(contracts, key=lambda x: x.strike)
+
+            for i, short_put in enumerate(contracts):
+                # Skip if no greeks
+                if short_put.greeks is None or short_put.greeks.delta is None:
+                    continue
+
+                # Check delta target
+                delta = abs(short_put.greeks.delta)
+                if abs(delta - self._target_delta) > 0.10:
+                    continue
+
+                # Find long put (lower strike for protection)
+                for long_put in contracts[:i]:
+                    if short_put.strike - long_put.strike != self._spread_width:
+                        continue
+
+                    # Calculate credit
+                    credit = short_put.bid_price - long_put.ask_price
+                    if credit < self._min_premium:
+                        continue
+
+                    if credit > best_credit:
+                        best_credit = credit
+                        best_spread = (short_put, long_put)
+
+        if best_spread is None:
+            return
+
+        short_put, long_put = best_spread
+
+        # Open the spread
+        self.market_order(short_put.symbol, -1)  # Sell higher strike
+        self.market_order(long_put.symbol, 1)    # Buy lower strike
+
+        self._positions[short_put.symbol] = short_put.bid_price
+        self._positions[long_put.symbol] = long_put.ask_price
+
+        self.log(f"Opened put credit spread: Sold {short_put.strike} / Bought {long_put.strike}, "
+                 f"Credit: {best_credit:.2f}")
+{% endif %}
+
+{% if strategy.parameters.sub_type == 'covered_call' %}
+    def _open_covered_call(self):
+        """Open a covered call position."""
+        # First ensure we own the underlying shares
+        underlying_holding = self.portfolio[self._underlying]
+        shares_needed = self._shares_per_contract - underlying_holding.quantity
+
+        if shares_needed > 0:
+            self.market_order(self._underlying, shares_needed)
+            self.log(f"Bought {shares_needed} shares of {self._underlying_ticker}")
+            return  # Wait for next bar to sell call
+
+        # Get option chain
+        chain = self.option_chain(self._option_symbol)
+        if not chain:
+            return
+
+        # Filter for calls
+        calls = [c for c in chain if c.right == OptionRight.CALL]
+        if not calls:
+            return
+
+        # Find call with target delta (OTM calls have positive delta < 0.5)
+        target_call = None
+        best_delta_diff = float('inf')
+
+        for contract in calls:
+            # Skip if no greeks
+            if contract.greeks is None or contract.greeks.delta is None:
+                continue
+
+            delta = contract.greeks.delta
+            delta_diff = abs(delta - self._target_delta)
+
+            # Check minimum premium
+            if contract.bid_price < self._min_premium:
+                continue
+
+            if delta_diff < best_delta_diff:
+                best_delta_diff = delta_diff
+                target_call = contract
+
+        if target_call is None:
+            return
+
+        # Sell the call (covered by shares)
+        self.market_order(target_call.symbol, -1)
+        self._positions[target_call.symbol] = target_call.bid_price
+        self.log(f"Sold covered call: {target_call.symbol}, Strike: {target_call.strike}, "
+                 f"DTE: {(target_call.expiry - self.time).days}, Premium: {target_call.bid_price:.2f}")
+{% endif %}
+
+    def on_data(self, data):
+        """Handle incoming data."""
+        pass
+
+    def on_order_event(self, order_event):
+        """Handle order events for logging."""
+        if order_event.status == OrderStatus.FILLED:
+            self.log(f"Order filled: {order_event.symbol}, Qty: {order_event.fill_quantity}, "
+                     f"Price: {order_event.fill_price:.2f}")

--- a/research_system/validation/v4_runner.py
+++ b/research_system/validation/v4_runner.py
@@ -188,10 +188,23 @@ class V4Runner:
 
         # Step 3: Run walk-forward backtest
         print(f"  Running walk-forward validation...")
-        wf_result = self.backtest_executor.run_walk_forward(
-            code=code_result.code,
-            strategy_id=strategy_id,
-        )
+
+        # Use correction loop if LLM is available
+        correction_attempts = 1
+        if self.llm_client:
+            wf_result, correction_attempts = self.backtest_executor.run_walk_forward_with_correction(
+                code=code_result.code,
+                strategy_id=strategy_id,
+                strategy=strategy,
+                code_generator=self.code_generator,
+            )
+            if correction_attempts > 1:
+                print(f"    Code corrected after {correction_attempts} attempts")
+        else:
+            wf_result = self.backtest_executor.run_walk_forward(
+                code=code_result.code,
+                strategy_id=strategy_id,
+            )
 
         # Check for blocking issues
         if wf_result.determination in ("BLOCKED", "RETRY_LATER"):

--- a/tests/v4/test_error_correction.py
+++ b/tests/v4/test_error_correction.py
@@ -1,0 +1,562 @@
+"""Tests for V4 error correction functionality.
+
+This module tests:
+1. Error classification (_is_correctable_error)
+2. Correction prompt generation
+3. Code correction method
+4. Retry logic with correction
+5. Max attempts limit
+"""
+
+import pytest
+from unittest.mock import Mock, MagicMock, patch
+
+from research_system.codegen.v4_generator import (
+    V4CodeGenerator,
+    V4CodeCorrectionResult,
+)
+from research_system.validation.backtest import (
+    BacktestExecutor,
+    BacktestResult,
+    CORRECTABLE_ERROR_PATTERNS,
+)
+
+
+# =============================================================================
+# TEST ERROR CLASSIFICATION
+# =============================================================================
+
+
+class TestErrorClassification:
+    """Test _is_correctable_error() classification logic."""
+
+    @pytest.fixture
+    def executor(self, tmp_path):
+        """Create a BacktestExecutor for testing."""
+        # Create minimal workspace structure
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / "validations").mkdir()
+        (workspace / "lean.json").write_text("{}")
+        return BacktestExecutor(workspace_path=workspace, cleanup_on_start=False)
+
+    def test_attribute_error_is_correctable(self, executor):
+        """Test AttributeError is classified as correctable."""
+        # Standard Python AttributeError format includes quotes around type
+        error = "AttributeError: 'QCAlgorithm' object has no attribute 'SetCash'"
+        assert executor._is_correctable_error(error)
+
+    def test_attribute_error_variant_is_correctable(self, executor):
+        """Test AttributeError variant without type quotes is correctable."""
+        # Some errors may have slightly different format
+        error = "AttributeError: type object 'Resolution' has no attribute 'daily'"
+        assert executor._is_correctable_error(error)
+
+    def test_name_error_is_correctable(self, executor):
+        """Test NameError is classified as correctable."""
+        error = "NameError: name 'Resolution' is not defined"
+        assert executor._is_correctable_error(error)
+
+    def test_type_error_is_correctable(self, executor):
+        """Test TypeError is classified as correctable."""
+        error = "TypeError: add_equity() takes 2 positional arguments but 3 were given"
+        assert executor._is_correctable_error(error)
+
+    def test_index_error_is_correctable(self, executor):
+        """Test IndexError is classified as correctable."""
+        error = "IndexError: list index out of range"
+        assert executor._is_correctable_error(error)
+
+    def test_key_error_is_correctable(self, executor):
+        """Test KeyError is classified as correctable."""
+        error = "KeyError: 'SPY'"
+        assert executor._is_correctable_error(error)
+
+    def test_resolution_error_is_correctable(self, executor):
+        """Test Resolution-related error is classified as correctable."""
+        error = "AttributeError: Resolution.daily does not exist"
+        assert executor._is_correctable_error(error)
+
+    def test_normalization_error_is_correctable(self, executor):
+        """Test DataNormalizationMode error is classified as correctable."""
+        error = "Options require DataNormalizationMode.RAW"
+        assert executor._is_correctable_error(error)
+
+    def test_syntax_error_is_correctable(self, executor):
+        """Test syntax error is classified as correctable."""
+        error = "SyntaxError: invalid syntax at line 42"
+        assert executor._is_correctable_error(error)
+
+    def test_missing_argument_is_correctable(self, executor):
+        """Test missing argument error is correctable."""
+        error = "TypeError: __init__() missing 2 required positional arguments"
+        assert executor._is_correctable_error(error)
+
+    def test_unexpected_keyword_is_correctable(self, executor):
+        """Test unexpected keyword argument error is correctable."""
+        error = "TypeError: add_equity() got an unexpected keyword argument 'foo'"
+        assert executor._is_correctable_error(error)
+
+    def test_empty_error_is_not_correctable(self, executor):
+        """Test empty error is not classified as correctable."""
+        assert not executor._is_correctable_error("")
+        assert not executor._is_correctable_error(None)
+
+    def test_rate_limit_error_is_not_correctable(self, executor):
+        """Test rate limit error is not classified as correctable."""
+        error = "No spare nodes available, please try again later"
+        assert not executor._is_correctable_error(error)
+
+    def test_generic_error_is_not_correctable(self, executor):
+        """Test generic error is not classified as correctable."""
+        error = "Something went wrong"
+        assert not executor._is_correctable_error(error)
+
+
+# =============================================================================
+# TEST CORRECTION PROMPT GENERATION
+# =============================================================================
+
+
+class TestCorrectionPrompt:
+    """Test correction prompt generation."""
+
+    @pytest.fixture
+    def generator(self):
+        """Create a V4CodeGenerator without LLM client."""
+        return V4CodeGenerator(llm_client=None)
+
+    def test_correction_prompt_includes_strategy_name(self, generator):
+        """Test prompt includes strategy name."""
+        code = "class Test: pass"
+        error = "Some error"
+        strategy = {"name": "My Test Strategy", "id": "STRAT-001"}
+
+        prompt = generator._build_correction_prompt(code, error, strategy)
+
+        assert "My Test Strategy" in prompt
+
+    def test_correction_prompt_includes_strategy_id(self, generator):
+        """Test prompt includes strategy ID."""
+        code = "class Test: pass"
+        error = "Some error"
+        strategy = {"name": "Test", "id": "STRAT-001"}
+
+        prompt = generator._build_correction_prompt(code, error, strategy)
+
+        assert "STRAT-001" in prompt
+
+    def test_correction_prompt_includes_error(self, generator):
+        """Test prompt includes the error message."""
+        code = "class Test: pass"
+        error = "AttributeError: object has no attribute 'foo'"
+        strategy = {"name": "Test", "id": "STRAT-001"}
+
+        prompt = generator._build_correction_prompt(code, error, strategy)
+
+        assert error in prompt
+
+    def test_correction_prompt_includes_code(self, generator):
+        """Test prompt includes the failed code."""
+        code = "class MyAlgorithm(QCAlgorithm):\n    pass"
+        error = "Some error"
+        strategy = {"name": "Test", "id": "STRAT-001"}
+
+        prompt = generator._build_correction_prompt(code, error, strategy)
+
+        assert code in prompt
+
+    def test_correction_prompt_includes_common_fixes(self, generator):
+        """Test prompt includes common fix hints."""
+        code = "class Test: pass"
+        error = "Some error"
+        strategy = {"name": "Test", "id": "STRAT-001"}
+
+        prompt = generator._build_correction_prompt(code, error, strategy)
+
+        assert "Resolution" in prompt
+        assert "snake_case" in prompt
+        assert "DataNormalizationMode" in prompt
+
+
+# =============================================================================
+# TEST CODE CORRECTION
+# =============================================================================
+
+
+class TestCodeCorrection:
+    """Test correct_code_error() method."""
+
+    def test_correction_without_llm_client_fails(self):
+        """Test correction fails without LLM client."""
+        generator = V4CodeGenerator(llm_client=None)
+
+        result = generator.correct_code_error(
+            original_code="class Test: pass",
+            error_message="Some error",
+            strategy={"name": "Test", "id": "STRAT-001"},
+        )
+
+        assert not result.success
+        assert "No LLM client" in result.error
+
+    def test_correction_with_llm_returns_corrected_code(self):
+        """Test correction with mocked LLM client."""
+        mock_llm = Mock()
+        mock_response = Mock()
+        mock_response.content = """```python
+from AlgorithmImports import *
+
+class TestAlgorithm(QCAlgorithm):
+    def initialize(self):
+        self.set_cash(100000)
+```"""
+        mock_llm.generate.return_value = mock_response
+
+        generator = V4CodeGenerator(llm_client=mock_llm)
+
+        result = generator.correct_code_error(
+            original_code="class Test: pass",
+            error_message="Some error",
+            strategy={"name": "Test", "id": "STRAT-001"},
+        )
+
+        assert result.success
+        assert result.corrected_code is not None
+        assert "QCAlgorithm" in result.corrected_code
+        mock_llm.generate.assert_called_once()
+
+    def test_correction_applies_post_processing(self):
+        """Test that correction applies _fix_qc_api_issues."""
+        mock_llm = Mock()
+        mock_response = Mock()
+        # LLM returns code with PascalCase (needs fixing)
+        mock_response.content = """```python
+class Test(QCAlgorithm):
+    def Initialize(self):
+        self.SetCash(100000)
+        self.AddEquity("SPY", Resolution.daily)
+```"""
+        mock_llm.generate.return_value = mock_response
+
+        generator = V4CodeGenerator(llm_client=mock_llm)
+
+        result = generator.correct_code_error(
+            original_code="class Test: pass",
+            error_message="Some error",
+            strategy={"name": "Test", "id": "STRAT-001"},
+        )
+
+        assert result.success
+        # Should have snake_case and uppercase Resolution
+        assert "set_cash" in result.corrected_code
+        assert "add_equity" in result.corrected_code
+        assert "Resolution.DAILY" in result.corrected_code
+
+    def test_correction_returns_attempt_number(self):
+        """Test that correction returns the attempt number."""
+        mock_llm = Mock()
+        mock_response = Mock()
+        mock_response.content = "```python\nclass Test: pass\n```"
+        mock_llm.generate.return_value = mock_response
+
+        generator = V4CodeGenerator(llm_client=mock_llm)
+
+        result = generator.correct_code_error(
+            original_code="class Test: pass",
+            error_message="Some error",
+            strategy={"name": "Test", "id": "STRAT-001"},
+            attempt=2,
+        )
+
+        assert result.attempt == 2
+
+    def test_correction_handles_llm_exception(self):
+        """Test that correction handles LLM exceptions gracefully."""
+        mock_llm = Mock()
+        mock_llm.generate.side_effect = Exception("LLM API error")
+
+        generator = V4CodeGenerator(llm_client=mock_llm)
+
+        result = generator.correct_code_error(
+            original_code="class Test: pass",
+            error_message="Some error",
+            strategy={"name": "Test", "id": "STRAT-001"},
+        )
+
+        assert not result.success
+        assert "Correction failed" in result.error
+
+    def test_correction_fails_if_no_code_extracted(self):
+        """Test correction fails if LLM doesn't return extractable code."""
+        mock_llm = Mock()
+        mock_response = Mock()
+        mock_response.content = "I don't know how to fix this."
+        mock_llm.generate.return_value = mock_response
+
+        generator = V4CodeGenerator(llm_client=mock_llm)
+
+        result = generator.correct_code_error(
+            original_code="class Test: pass",
+            error_message="Some error",
+            strategy={"name": "Test", "id": "STRAT-001"},
+        )
+
+        assert not result.success
+        assert "Could not extract corrected code" in result.error
+
+
+# =============================================================================
+# TEST V4CodeCorrectionResult DATACLASS
+# =============================================================================
+
+
+class TestV4CodeCorrectionResult:
+    """Test V4CodeCorrectionResult dataclass."""
+
+    def test_to_dict_success(self):
+        """Test to_dict for successful correction."""
+        result = V4CodeCorrectionResult(
+            success=True,
+            corrected_code="class Test: pass",
+            attempt=2,
+        )
+
+        d = result.to_dict()
+
+        assert d["success"] is True
+        assert d["corrected_code"] == "class Test: pass"
+        assert d["error"] is None
+        assert d["attempt"] == 2
+
+    def test_to_dict_failure(self):
+        """Test to_dict for failed correction."""
+        result = V4CodeCorrectionResult(
+            success=False,
+            error="No LLM client",
+            attempt=1,
+        )
+
+        d = result.to_dict()
+
+        assert d["success"] is False
+        assert d["corrected_code"] is None
+        assert d["error"] == "No LLM client"
+        assert d["attempt"] == 1
+
+
+# =============================================================================
+# TEST RETRY LOGIC
+# =============================================================================
+
+
+class TestRetryLogic:
+    """Test run_single_with_correction retry logic."""
+
+    @pytest.fixture
+    def executor(self, tmp_path):
+        """Create a BacktestExecutor with mock run_single."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / "validations").mkdir()
+        (workspace / "lean.json").write_text("{}")
+        return BacktestExecutor(workspace_path=workspace, cleanup_on_start=False)
+
+    def test_success_on_first_try_returns_immediately(self, executor):
+        """Test that success on first try returns without correction."""
+        strategy = {"name": "Test", "id": "STRAT-001"}
+        mock_generator = Mock()
+
+        # Mock run_single to succeed immediately
+        with patch.object(executor, 'run_single') as mock_run:
+            mock_run.return_value = BacktestResult(success=True, cagr=0.15, sharpe=1.5)
+
+            result, attempts = executor.run_single_with_correction(
+                code="class Test: pass",
+                start_date="2020-01-01",
+                end_date="2022-12-31",
+                strategy_id="STRAT-001",
+                strategy=strategy,
+                code_generator=mock_generator,
+                max_attempts=3,
+            )
+
+        assert result.success
+        assert attempts == 1
+        mock_generator.correct_code_error.assert_not_called()
+
+    def test_correction_attempted_on_correctable_error(self, executor):
+        """Test that correction is attempted on correctable error."""
+        strategy = {"name": "Test", "id": "STRAT-001"}
+
+        mock_generator = Mock()
+        mock_generator.correct_code_error.return_value = V4CodeCorrectionResult(
+            success=True,
+            corrected_code="class Fixed: pass",
+        )
+
+        call_count = [0]
+
+        def run_single_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return BacktestResult(
+                    success=False,
+                    error="AttributeError: 'QCAlgorithm' object has no attribute 'foo'"
+                )
+            return BacktestResult(success=True, cagr=0.15, sharpe=1.5)
+
+        with patch.object(executor, 'run_single', side_effect=run_single_side_effect):
+            result, attempts = executor.run_single_with_correction(
+                code="class Test: pass",
+                start_date="2020-01-01",
+                end_date="2022-12-31",
+                strategy_id="STRAT-001",
+                strategy=strategy,
+                code_generator=mock_generator,
+                max_attempts=3,
+            )
+
+        assert result.success
+        assert attempts == 2
+        mock_generator.correct_code_error.assert_called_once()
+
+    def test_max_attempts_respected(self, executor):
+        """Test that max_attempts limit is respected."""
+        strategy = {"name": "Test", "id": "STRAT-001"}
+
+        mock_generator = Mock()
+        mock_generator.correct_code_error.return_value = V4CodeCorrectionResult(
+            success=True,
+            corrected_code="class StillBroken: pass",
+        )
+
+        # Always fail with correctable error
+        with patch.object(executor, 'run_single') as mock_run:
+            mock_run.return_value = BacktestResult(
+                success=False,
+                error="AttributeError: 'QCAlgorithm' object has no attribute 'foo'"
+            )
+
+            result, attempts = executor.run_single_with_correction(
+                code="class Test: pass",
+                start_date="2020-01-01",
+                end_date="2022-12-31",
+                strategy_id="STRAT-001",
+                strategy=strategy,
+                code_generator=mock_generator,
+                max_attempts=3,
+            )
+
+        assert not result.success
+        assert attempts == 3
+        # Correction called twice (after attempt 1 and 2, not after attempt 3)
+        assert mock_generator.correct_code_error.call_count == 2
+
+    def test_no_correction_for_non_correctable_error(self, executor):
+        """Test that non-correctable errors don't trigger correction."""
+        strategy = {"name": "Test", "id": "STRAT-001"}
+        mock_generator = Mock()
+
+        with patch.object(executor, 'run_single') as mock_run:
+            mock_run.return_value = BacktestResult(
+                success=False,
+                error="Something completely different happened"
+            )
+
+            result, attempts = executor.run_single_with_correction(
+                code="class Test: pass",
+                start_date="2020-01-01",
+                end_date="2022-12-31",
+                strategy_id="STRAT-001",
+                strategy=strategy,
+                code_generator=mock_generator,
+                max_attempts=3,
+            )
+
+        assert not result.success
+        assert attempts == 1
+        mock_generator.correct_code_error.assert_not_called()
+
+    def test_no_correction_for_rate_limited(self, executor):
+        """Test that rate limited errors don't trigger correction."""
+        strategy = {"name": "Test", "id": "STRAT-001"}
+        mock_generator = Mock()
+
+        with patch.object(executor, 'run_single') as mock_run:
+            mock_run.return_value = BacktestResult(
+                success=False,
+                error="No spare nodes",
+                rate_limited=True,
+            )
+
+            result, attempts = executor.run_single_with_correction(
+                code="class Test: pass",
+                start_date="2020-01-01",
+                end_date="2022-12-31",
+                strategy_id="STRAT-001",
+                strategy=strategy,
+                code_generator=mock_generator,
+                max_attempts=3,
+            )
+
+        assert not result.success
+        assert result.rate_limited
+        mock_generator.correct_code_error.assert_not_called()
+
+    def test_no_correction_for_engine_crash(self, executor):
+        """Test that engine crashes don't trigger correction."""
+        strategy = {"name": "Test", "id": "STRAT-001"}
+        mock_generator = Mock()
+
+        with patch.object(executor, 'run_single') as mock_run:
+            mock_run.return_value = BacktestResult(
+                success=False,
+                error="PAL_SEHException",
+                engine_crash=True,
+            )
+
+            result, attempts = executor.run_single_with_correction(
+                code="class Test: pass",
+                start_date="2020-01-01",
+                end_date="2022-12-31",
+                strategy_id="STRAT-001",
+                strategy=strategy,
+                code_generator=mock_generator,
+                max_attempts=3,
+            )
+
+        assert not result.success
+        assert result.engine_crash
+        mock_generator.correct_code_error.assert_not_called()
+
+    def test_stops_if_correction_fails(self, executor):
+        """Test that we stop retrying if correction itself fails."""
+        strategy = {"name": "Test", "id": "STRAT-001"}
+
+        mock_generator = Mock()
+        mock_generator.correct_code_error.return_value = V4CodeCorrectionResult(
+            success=False,
+            error="Could not extract code",
+        )
+
+        with patch.object(executor, 'run_single') as mock_run:
+            mock_run.return_value = BacktestResult(
+                success=False,
+                error="AttributeError: 'QCAlgorithm' object has no attribute 'foo'"
+            )
+
+            result, attempts = executor.run_single_with_correction(
+                code="class Test: pass",
+                start_date="2020-01-01",
+                end_date="2022-12-31",
+                strategy_id="STRAT-001",
+                strategy=strategy,
+                code_generator=mock_generator,
+                max_attempts=3,
+            )
+
+        assert not result.success
+        assert attempts == 1
+        # Only one correction attempt before stopping
+        mock_generator.correct_code_error.assert_called_once()

--- a/tests/v4/test_options_template.py
+++ b/tests/v4/test_options_template.py
@@ -1,0 +1,348 @@
+"""Tests for V4 options income strategy template.
+
+This module tests:
+1. Template selection for options strategy types
+2. Code generation for each sub-type (cash_secured_put, put_credit_spread, covered_call)
+3. DataNormalizationMode.RAW is present
+4. PascalCase option filter methods are used correctly
+"""
+
+import pytest
+
+from research_system.codegen.v4_generator import V4CodeGenerator
+from research_system.codegen.templates.v4 import get_template_for_v4_strategy
+
+
+# =============================================================================
+# TEST TEMPLATE SELECTION
+# =============================================================================
+
+
+class TestOptionsTemplateSelection:
+    """Test template selection for options strategy types."""
+
+    def test_options_income_selects_template(self):
+        """Test options_income strategy type selects options_income.py.j2."""
+        template = get_template_for_v4_strategy("options_income")
+        assert template == "options_income.py.j2"
+
+    def test_options_income_hyphenated_selects_template(self):
+        """Test options-income (hyphenated) selects template."""
+        template = get_template_for_v4_strategy("options-income")
+        assert template == "options_income.py.j2"
+
+    def test_cash_secured_put_selects_template(self):
+        """Test cash_secured_put strategy type selects options_income.py.j2."""
+        template = get_template_for_v4_strategy("cash_secured_put")
+        assert template == "options_income.py.j2"
+
+    def test_put_credit_spread_selects_template(self):
+        """Test put_credit_spread strategy type selects options_income.py.j2."""
+        template = get_template_for_v4_strategy("put_credit_spread")
+        assert template == "options_income.py.j2"
+
+    def test_covered_call_selects_template(self):
+        """Test covered_call strategy type selects options_income.py.j2."""
+        template = get_template_for_v4_strategy("covered_call")
+        assert template == "options_income.py.j2"
+
+    def test_generic_options_selects_template(self):
+        """Test generic 'options' strategy type selects options_income.py.j2."""
+        template = get_template_for_v4_strategy("options")
+        assert template == "options_income.py.j2"
+
+
+# =============================================================================
+# TEST CODE GENERATION
+# =============================================================================
+
+
+class TestOptionsCodeGeneration:
+    """Test options income code generation."""
+
+    @pytest.fixture
+    def generator(self):
+        """Create a code generator without LLM client."""
+        return V4CodeGenerator(llm_client=None)
+
+    @pytest.fixture
+    def cash_secured_put_strategy(self):
+        """Sample cash-secured put strategy document."""
+        return {
+            "id": "STRAT-OPT-001",
+            "name": "SPY Cash Secured Puts",
+            "description": "Sell cash-secured puts on SPY for income",
+            "strategy_type": "options_income",
+            "parameters": {
+                "sub_type": "cash_secured_put",
+                "underlying": "SPY",
+                "target_delta": 0.30,
+                "min_dte": 30,
+                "max_dte": 45,
+                "min_premium": 1.00,
+                "profit_target": 0.50,
+                "initial_capital": 100000,
+            },
+        }
+
+    @pytest.fixture
+    def put_credit_spread_strategy(self):
+        """Sample put credit spread strategy document."""
+        return {
+            "id": "STRAT-OPT-002",
+            "name": "SPY Put Credit Spreads",
+            "description": "Bull put spreads on SPY for defined-risk income",
+            "strategy_type": "options_income",
+            "parameters": {
+                "sub_type": "put_credit_spread",
+                "underlying": "SPY",
+                "target_delta": 0.25,
+                "spread_width": 5,
+                "min_dte": 30,
+                "max_dte": 45,
+                "min_premium": 0.75,
+                "initial_capital": 50000,
+            },
+        }
+
+    @pytest.fixture
+    def covered_call_strategy(self):
+        """Sample covered call strategy document."""
+        return {
+            "id": "STRAT-OPT-003",
+            "name": "SPY Covered Calls",
+            "description": "Covered calls on SPY for income",
+            "strategy_type": "options_income",
+            "parameters": {
+                "sub_type": "covered_call",
+                "underlying": "SPY",
+                "target_delta": 0.30,
+                "min_dte": 14,
+                "max_dte": 30,
+                "min_premium": 0.50,
+                "initial_capital": 100000,
+            },
+        }
+
+    def test_cash_secured_put_generates_valid_code(self, generator, cash_secured_put_strategy):
+        """Test cash-secured put strategy generates valid Python code."""
+        result = generator.generate(cash_secured_put_strategy)
+
+        assert result.success
+        assert result.code is not None
+        assert result.method == "template"
+        assert result.template_used == "options_income.py.j2"
+
+        # Check class name
+        assert "class StratOpt001Algorithm(QCAlgorithm):" in result.code
+
+        # Check strategy-specific method
+        assert "_open_cash_secured_put" in result.code
+
+    def test_put_credit_spread_generates_valid_code(self, generator, put_credit_spread_strategy):
+        """Test put credit spread strategy generates valid Python code."""
+        result = generator.generate(put_credit_spread_strategy)
+
+        assert result.success
+        assert result.code is not None
+        assert result.method == "template"
+
+        # Check class name
+        assert "class StratOpt002Algorithm(QCAlgorithm):" in result.code
+
+        # Check strategy-specific method
+        assert "_open_put_credit_spread" in result.code
+
+        # Check spread width parameter
+        assert "spread_width" in result.code.lower() or "_spread_width" in result.code
+
+    def test_covered_call_generates_valid_code(self, generator, covered_call_strategy):
+        """Test covered call strategy generates valid Python code."""
+        result = generator.generate(covered_call_strategy)
+
+        assert result.success
+        assert result.code is not None
+        assert result.method == "template"
+
+        # Check class name
+        assert "class StratOpt003Algorithm(QCAlgorithm):" in result.code
+
+        # Check strategy-specific method
+        assert "_open_covered_call" in result.code
+
+
+# =============================================================================
+# TEST REQUIRED OPTIONS COMPONENTS
+# =============================================================================
+
+
+class TestOptionsRequiredComponents:
+    """Test that generated options code has required components."""
+
+    @pytest.fixture
+    def generator(self):
+        return V4CodeGenerator(llm_client=None)
+
+    @pytest.fixture
+    def options_strategy(self):
+        """Basic options strategy for testing required components."""
+        return {
+            "id": "STRAT-OPT-TEST",
+            "name": "Test Options Strategy",
+            "strategy_type": "options_income",
+            "parameters": {
+                "sub_type": "cash_secured_put",
+                "underlying": "SPY",
+            },
+        }
+
+    def test_has_data_normalization_mode_raw(self, generator, options_strategy):
+        """Test that DataNormalizationMode.RAW is set on underlying equity."""
+        result = generator.generate(options_strategy)
+
+        assert result.success
+        assert "DataNormalizationMode.RAW" in result.code
+
+    def test_has_set_data_normalization_mode_call(self, generator, options_strategy):
+        """Test that set_data_normalization_mode is called."""
+        result = generator.generate(options_strategy)
+
+        assert result.success
+        assert "set_data_normalization_mode" in result.code
+
+    def test_has_add_equity_for_underlying(self, generator, options_strategy):
+        """Test that add_equity is called for the underlying."""
+        result = generator.generate(options_strategy)
+
+        assert result.success
+        assert "add_equity" in result.code
+
+    def test_has_add_option_call(self, generator, options_strategy):
+        """Test that add_option is called."""
+        result = generator.generate(options_strategy)
+
+        assert result.success
+        assert "add_option" in result.code
+
+    def test_has_include_weeklys_pascal_case(self, generator, options_strategy):
+        """Test that IncludeWeeklys uses PascalCase (not include_weeklys)."""
+        result = generator.generate(options_strategy)
+
+        assert result.success
+        assert "IncludeWeeklys()" in result.code
+        assert "include_weeklys" not in result.code.lower().replace("includeweeklys", "")
+
+    def test_has_strikes_pascal_case(self, generator, options_strategy):
+        """Test that Strikes uses PascalCase."""
+        result = generator.generate(options_strategy)
+
+        assert result.success
+        assert ".Strikes(" in result.code
+
+    def test_has_expiration_pascal_case(self, generator, options_strategy):
+        """Test that Expiration uses PascalCase."""
+        result = generator.generate(options_strategy)
+
+        assert result.success
+        assert ".Expiration(" in result.code
+
+    def test_has_algorithm_imports(self, generator, options_strategy):
+        """Test that AlgorithmImports is imported."""
+        result = generator.generate(options_strategy)
+
+        assert result.success
+        assert "from AlgorithmImports import *" in result.code
+
+    def test_has_initialize_method(self, generator, options_strategy):
+        """Test that initialize method is defined."""
+        result = generator.generate(options_strategy)
+
+        assert result.success
+        assert "def initialize(self):" in result.code
+
+    def test_has_option_chain_usage(self, generator, options_strategy):
+        """Test that option_chain is used."""
+        result = generator.generate(options_strategy)
+
+        assert result.success
+        assert "option_chain" in result.code
+
+
+# =============================================================================
+# TEST PARAMETER HANDLING
+# =============================================================================
+
+
+class TestOptionsParameterHandling:
+    """Test that options template handles parameters correctly."""
+
+    @pytest.fixture
+    def generator(self):
+        return V4CodeGenerator(llm_client=None)
+
+    def test_custom_underlying(self, generator):
+        """Test custom underlying symbol is used."""
+        strategy = {
+            "id": "STRAT-QQQ",
+            "name": "QQQ Options",
+            "strategy_type": "options_income",
+            "parameters": {
+                "sub_type": "cash_secured_put",
+                "underlying": "QQQ",
+            },
+        }
+        result = generator.generate(strategy)
+
+        assert result.success
+        assert '"QQQ"' in result.code
+
+    def test_custom_delta(self, generator):
+        """Test custom target delta is used."""
+        strategy = {
+            "id": "STRAT-DELTA",
+            "name": "Custom Delta",
+            "strategy_type": "options_income",
+            "parameters": {
+                "sub_type": "cash_secured_put",
+                "target_delta": 0.15,
+            },
+        }
+        result = generator.generate(strategy)
+
+        assert result.success
+        assert "0.15" in result.code
+
+    def test_custom_dte_range(self, generator):
+        """Test custom DTE range is used in filter."""
+        strategy = {
+            "id": "STRAT-DTE",
+            "name": "Custom DTE",
+            "strategy_type": "options_income",
+            "parameters": {
+                "sub_type": "cash_secured_put",
+                "min_dte": 14,
+                "max_dte": 21,
+            },
+        }
+        result = generator.generate(strategy)
+
+        assert result.success
+        assert ".Expiration(14, 21)" in result.code
+
+    def test_default_values_used(self, generator):
+        """Test that defaults are used when parameters not specified."""
+        strategy = {
+            "id": "STRAT-DEFAULTS",
+            "name": "Default Values",
+            "strategy_type": "options_income",
+            "parameters": {
+                "sub_type": "cash_secured_put",
+            },
+        }
+        result = generator.generate(strategy)
+
+        assert result.success
+        # Default underlying is SPY
+        assert '"SPY"' in result.code
+        # Default delta is 0.30
+        assert "0.30" in result.code or "0.3" in result.code


### PR DESCRIPTION
## Summary
- Adds deterministic `options_income.py.j2` template for cash-secured puts, put credit spreads, and covered calls
- Implements LLM error correction loop to automatically fix correctable backtest errors
- Fixes #145

## Changes
### Options Income Template
- Sets `DataNormalizationMode.RAW` on underlying equity (required for options)
- Uses PascalCase for option filter methods (`IncludeWeeklys`, `Strikes`, `Expiration`)
- Template registry mappings for multiple strategy types

### Error Correction Loop
- `V4CodeCorrectionResult` dataclass for correction results
- `correct_code_error()` method with common fix hints in prompt
- Error classification via `CORRECTABLE_ERROR_PATTERNS`
- `run_single_with_correction()` and `run_walk_forward_with_correction()` methods
- Max 3 correction attempts to prevent infinite loops

## Test plan
- [x] 23 tests for options template (selection, generation, required components)
- [x] 34 tests for error correction (classification, prompts, retry logic)
- [x] All 402 V4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)