### PR TITLE
feat: Reduce default walk-forward windows from 5 to 2 (#149)

### DIFF
--- a/research_system/cli/main.py
+++ b/research_system/cli/main.py
@@ -1034,6 +1034,13 @@ Examples:
         help="Skip verification check before running"
     )
     parser.add_argument(
+        "--windows",
+        type=int,
+        default=2,
+        choices=[2, 5],
+        help="Number of walk-forward windows: 2 (fast, IS/OOS style) or 5 (thorough). Default: 2"
+    )
+    parser.add_argument(
         "--workspace", "-w",
         dest="v4_workspace",
         metavar="PATH",
@@ -2072,6 +2079,7 @@ def cmd_v4_run(args):
     dry_run = getattr(args, 'dry_run', False)
     force_llm = getattr(args, 'force_llm', False)
     skip_verify = getattr(args, 'skip_verify', False)
+    num_windows = getattr(args, 'windows', 2)
 
     if not strategy_id and not run_all:
         print("Error: Strategy ID required or use --all")
@@ -2098,12 +2106,14 @@ def cmd_v4_run(args):
         workspace=workspace,
         llm_client=llm_client,
         use_local=use_local,
+        num_windows=num_windows,
     )
 
     print("\n" + "=" * 60)
     print("  V4 Validation Pipeline")
     print("=" * 60)
     print(f"\nBacktest mode: {'Local Docker' if use_local else 'QC Cloud'}")
+    print(f"Walk-forward windows: {num_windows}")
     if dry_run:
         print("[DRY RUN] No backtests will be executed")
     print()

--- a/research_system/validation/v4_runner.py
+++ b/research_system/validation/v4_runner.py
@@ -78,6 +78,7 @@ class V4Runner:
         workspace,
         llm_client=None,
         use_local: bool = False,
+        num_windows: int = 2,
     ):
         """Initialize the V4 runner.
 
@@ -85,10 +86,12 @@ class V4Runner:
             workspace: V4Workspace instance
             llm_client: Optional LLM client for code generation
             use_local: Use local Docker instead of QC cloud
+            num_windows: Number of walk-forward windows (2 or 5)
         """
         self.workspace = workspace
         self.llm_client = llm_client
         self.use_local = use_local
+        self.num_windows = num_windows
 
         # Initialize code generator
         self.code_generator = V4CodeGenerator(llm_client)
@@ -98,6 +101,7 @@ class V4Runner:
             workspace_path=workspace.path,
             use_local=use_local,
             cleanup_on_start=not use_local,
+            num_windows=num_windows,
         )
 
         # Load config for gates
@@ -476,7 +480,7 @@ class V4Runner:
         print(f"    min_consistency: {config_gates.min_consistency}")
         print(f"    max_drawdown: {config_gates.max_drawdown}")
 
-        print(f"  Walk-forward windows: 5 (default)")
+        print(f"  Walk-forward windows: {self.num_windows}")
         print(f"  Backtest mode: {'Local Docker' if self.use_local else 'QC Cloud'}")
 
         return V4RunResult(


### PR DESCRIPTION
## Summary

- Change default from 5 rolling windows to 2 (IS/OOS style)
- Add `--windows` flag to v4-run command (choices: 2 or 5)
- Default: 2 windows (2012-2017 IS, 2018-2023 OOS)  
- Use `--windows 5` for thorough validation with 5 rolling windows

This reduces resource usage for single-node QC accounts (from 5 backtests to 2) while maintaining the option for thorough validation when needed.

## Test plan

- [x] All 402 V4 tests pass
- [x] CLI help shows new `--windows` flag
- [ ] Test with `research v4-run STRAT-XXX` (uses default 2 windows)
- [ ] Test with `research v4-run --windows 5 STRAT-XXX` (uses 5 windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)