### PR TITLE
feat: Change default to 1 walk-forward window

### DIFF
--- a/research_system/cli/main.py
+++ b/research_system/cli/main.py
@@ -1036,9 +1036,9 @@ Examples:
     parser.add_argument(
         "--windows",
         type=int,
-        default=2,
-        choices=[2, 5],
-        help="Number of walk-forward windows: 2 (fast, IS/OOS style) or 5 (thorough). Default: 2"
+        default=1,
+        choices=[1, 2, 5],
+        help="Number of walk-forward windows: 1 (fastest), 2 (IS/OOS), or 5 (thorough). Default: 1"
     )
     parser.add_argument(
         "--workspace", "-w",
@@ -2079,7 +2079,7 @@ def cmd_v4_run(args):
     dry_run = getattr(args, 'dry_run', False)
     force_llm = getattr(args, 'force_llm', False)
     skip_verify = getattr(args, 'skip_verify', False)
-    num_windows = getattr(args, 'windows', 2)
+    num_windows = getattr(args, 'windows', 1)
 
     if not strategy_id and not run_all:
         print("Error: Strategy ID required or use --all")

--- a/research_system/validation/backtest.py
+++ b/research_system/validation/backtest.py
@@ -153,9 +153,14 @@ class BacktestExecutor:
         ("2020-01-01", "2023-12-31"),
     ]
 
-    # Default: 2 windows (similar to old IS/OOS approach, faster iteration)
-    # Use --windows 5 for thorough validation
+    # Default: 1 window (fastest iteration for single-node accounts)
+    # Use --windows 2 for IS/OOS, --windows 5 for thorough validation
     DEFAULT_WINDOWS = [
+        ("2012-01-01", "2023-12-31"),  # Full period
+    ]
+
+    # 2 windows: IS/OOS style
+    TWO_WINDOWS = [
         ("2012-01-01", "2017-12-31"),  # In-sample period
         ("2018-01-01", "2023-12-31"),  # Out-of-sample period
     ]
@@ -165,7 +170,7 @@ class BacktestExecutor:
         workspace_path: Path,
         use_local: bool = False,
         cleanup_on_start: bool = True,
-        num_windows: int = 2,
+        num_windows: int = 1,
     ):
         """Initialize backtest executor.
 
@@ -173,7 +178,7 @@ class BacktestExecutor:
             workspace_path: Path to the V4 workspace
             use_local: If True, use local Docker; if False, use QC cloud
             cleanup_on_start: If True, clean up stuck backtests on init
-            num_windows: Number of walk-forward windows (2 or 5)
+            num_windows: Number of walk-forward windows (1, 2, or 5)
         """
         self.workspace_path = Path(workspace_path)
         self.validations_path = self.workspace_path / "validations"
@@ -183,6 +188,8 @@ class BacktestExecutor:
         # Select windows based on num_windows
         if num_windows >= 5:
             self.windows = self.ALL_WINDOWS
+        elif num_windows == 2:
+            self.windows = self.TWO_WINDOWS
         else:
             self.windows = self.DEFAULT_WINDOWS
 

--- a/research_system/validation/v4_runner.py
+++ b/research_system/validation/v4_runner.py
@@ -78,7 +78,7 @@ class V4Runner:
         workspace,
         llm_client=None,
         use_local: bool = False,
-        num_windows: int = 2,
+        num_windows: int = 1,
     ):
         """Initialize the V4 runner.
 
@@ -86,7 +86,7 @@ class V4Runner:
             workspace: V4Workspace instance
             llm_client: Optional LLM client for code generation
             use_local: Use local Docker instead of QC cloud
-            num_windows: Number of walk-forward windows (2 or 5)
+            num_windows: Number of walk-forward windows (1, 2, or 5)
         """
         self.workspace = workspace
         self.llm_client = llm_client


### PR DESCRIPTION
## Summary

- Default: 1 window (2012-2023 full period) - fastest for single-node accounts
- `--windows 2`: IS/OOS style (2012-2017, 2018-2023)
- `--windows 5`: Thorough validation with 5 rolling windows

Optimized for single-node QC accounts to iterate faster through strategies.

## Test plan

- [x] All 402 V4 tests pass
- [ ] Test `research v4-run STRAT-XXX` (1 window default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)