### PR TITLE
fix: Add common LLM data requirement variations to QC_NATIVE_SPECIAL

### DIFF
--- a/research_system/core/data_registry.py
+++ b/research_system/core/data_registry.py
@@ -163,13 +163,34 @@ class DataRegistry:
         "iv_percentile",       # Derivable from options chain
         "iv_rank",             # Derivable from options chain
         "put_call_ratio",      # Derivable from options chain
+        # Options aliases (LLM variations)
+        "option_chain_data",   # Alias for options_data
+        "options_chains",      # Alias for options_data
+        "option_chains",       # Alias for options_data
+        "options_prices",      # Alias for options_data
+        "option_prices",       # Alias for options_data
         # Returns and volatility (derivable from price data)
         "historical_returns",  # Derivable from price data
         "historical_volatility", # Derivable from price data
         "realized_volatility", # Derivable from price data
+        "volatility_measures", # Derivable from price data
         # Breadth indicators
         "market_breadth",      # Derivable from constituent data
         "advance_decline",     # Derivable from constituent data
+        # Price-related (always derivable from OHLCV)
+        "underlying_prices",   # Just price data
+        "price_levels",        # Derivable from price data
+        # Technical indicators (all derivable from price data)
+        "support_resistance_levels",  # Computed from price data
+        "support_levels",      # Computed from price data
+        "resistance_levels",   # Computed from price data
+        "moving_averages",     # Computed from price data
+        "breakout_levels",     # Computed from price data
+        "trend_indicators",    # Computed from price data
+        "momentum_indicators", # Computed from price data
+        "position_sizing_data", # Computed/user-defined
+        "daily_high_low",      # Standard OHLCV data
+        "intraday_prices",     # Standard price data
     }
 
     # Mapping of semantic data requirement names to QC Native symbols/data types


### PR DESCRIPTION
## Summary
Added aliases and computed indicator patterns to prevent false BLOCKED status when the LLM extracts data requirements using varied terminology.

## Problem
LLM generates variations like `option_chain_data` but system expected `options_data`, causing strategies to be incorrectly marked as BLOCKED.

## Changes
- Options aliases: `option_chain_data`, `options_chains`, `options_prices`
- Price aliases: `underlying_prices`, `price_levels`
- Computed indicators: `support_resistance_levels`, `moving_averages`, `breakout_levels`, `volatility_measures`, `position_sizing_data`

## Test
```python
from research_system.core.data_registry import DataRegistry
DataRegistry.is_qc_native_pattern("option_chain_data")  # Now returns True
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)