### PR TITLE
fix: make backtest timeout configurable, increase default to 600s (#176)

### DIFF
--- a/research_system/cli/main.py
+++ b/research_system/cli/main.py
@@ -2307,6 +2307,7 @@ def cmd_v4_walkforward(args):
     backtest_executor = BacktestExecutor(
         workspace_path=workspace.path,
         use_local=False,
+        timeout=workspace.config.backtest.timeout,
     )
     code_generator = V4CodeGenerator()
 

--- a/research_system/core/v4/__init__.py
+++ b/research_system/core/v4/__init__.py
@@ -51,6 +51,7 @@ from research_system.core.v4.config import (
     VerificationConfig,
     ScoringConfig,
     RedFlagsConfig,
+    BacktestConfig,
     LoggingConfig,
     APIConfig,
     # Loading functions
@@ -89,6 +90,7 @@ __all__ = [
     "VerificationConfig",
     "ScoringConfig",
     "RedFlagsConfig",
+    "BacktestConfig",
     "LoggingConfig",
     "APIConfig",
     # Loading functions

--- a/research_system/core/v4/config.py
+++ b/research_system/core/v4/config.py
@@ -204,6 +204,17 @@ class RedFlagsConfig(BaseModel):
     )
 
 
+class BacktestConfig(BaseModel):
+    """Backtest execution configuration.
+
+    Controls timeouts and other execution parameters for backtests.
+    """
+
+    timeout: int = Field(
+        600, ge=60, description="Backtest execution timeout in seconds (default: 600)"
+    )
+
+
 class LoggingConfig(BaseModel):
     """Logging configuration."""
 
@@ -260,6 +271,9 @@ class V4Config(BaseModel):
     )
     red_flags: RedFlagsConfig = Field(
         default_factory=RedFlagsConfig, description="Red flag configuration"
+    )
+    backtest: BacktestConfig = Field(
+        default_factory=BacktestConfig, description="Backtest execution configuration"
     )
     logging: LoggingConfig = Field(
         default_factory=LoggingConfig, description="Logging configuration"

--- a/research_system/validation/backtest.py
+++ b/research_system/validation/backtest.py
@@ -171,6 +171,7 @@ class BacktestExecutor:
         use_local: bool = False,
         cleanup_on_start: bool = True,
         num_windows: int = 1,
+        timeout: int = 600,
     ):
         """Initialize backtest executor.
 
@@ -179,11 +180,13 @@ class BacktestExecutor:
             use_local: If True, use local Docker; if False, use QC cloud
             cleanup_on_start: If True, clean up stuck backtests on init
             num_windows: Number of walk-forward windows (1, 2, or 5)
+            timeout: Backtest execution timeout in seconds (default: 600)
         """
         self.workspace_path = Path(workspace_path)
         self.validations_path = self.workspace_path / "validations"
         self.use_local = use_local
         self.num_windows = num_windows
+        self.timeout = timeout
 
         # Select windows based on num_windows
         if num_windows >= 5:
@@ -563,7 +566,7 @@ class BacktestExecutor:
             cmd,
             capture_output=True,
             text=True,
-            timeout=300,
+            timeout=self.timeout,
             cwd=str(self.workspace_path),
         )
 

--- a/research_system/validation/v4_runner.py
+++ b/research_system/validation/v4_runner.py
@@ -96,16 +96,17 @@ class V4Runner:
         # Initialize code generator
         self.code_generator = V4CodeGenerator(llm_client)
 
+        # Load config for gates
+        self._config = workspace.config
+
         # Initialize backtest executor
         self.backtest_executor = BacktestExecutor(
             workspace_path=workspace.path,
             use_local=use_local,
             cleanup_on_start=not use_local,
             num_windows=num_windows,
+            timeout=self._config.backtest.timeout,
         )
-
-        # Load config for gates
-        self._config = workspace.config
 
     def run(
         self,


### PR DESCRIPTION
Fixes #176. Backtest timeout is now configurable and defaults to 600 seconds instead of the previous short timeout that was insufficient for options strategies.