### PR TITLE
fix: add Lean CLI guidance to init and improve backtest error message (#173)

### DIFF
--- a/research_system/cli/main.py
+++ b/research_system/cli/main.py
@@ -26,6 +26,7 @@ Run 'research <command> --help' for more information on a command.
 
 import argparse
 import json
+import shutil
 import sys
 from pathlib import Path
 from typing import Optional
@@ -1335,6 +1336,11 @@ def cmd_init_v4(args):
     print("  3. Run 'research ingest' to create strategy documents")
     print("  4. Run 'research verify STRAT-001' to run verification tests")
     print("  5. Run 'research validate STRAT-001' to run walk-forward validation")
+
+    if shutil.which("lean"):
+        print()
+        print("Note: Run 'lean init' in your workspace to enable QuantConnect backtesting.")
+
     return 0
 
 

--- a/research_system/validation/backtest.py
+++ b/research_system/validation/backtest.py
@@ -549,7 +549,7 @@ class BacktestExecutor:
         if not lean_config.exists():
             return BacktestResult(
                 success=False,
-                error=f"No lean.json found in workspace. Run 'lean init' in {self.workspace_path} first.",
+                error=f"No lean.json found. Run 'lean init' in your workspace directory to set up QuantConnect backtesting. See the README for details.",
             )
 
         # Build command


### PR DESCRIPTION
Fixes #173. The init command now provides guidance on setting up Lean CLI, and backtest error messages are more informative.