### PR TITLE
feat: add --force flag to run command for retrying blocked strategies (#178)

### DIFF
--- a/research_system/cli/main.py
+++ b/research_system/cli/main.py
@@ -1034,6 +1034,11 @@ Examples:
         help="Skip verification check before running"
     )
     parser.add_argument(
+        "--force", "-f",
+        action="store_true",
+        help="Re-run blocked strategies (moves from blocked/ to pending/ and retries)"
+    )
+    parser.add_argument(
         "--windows",
         type=int,
         default=1,
@@ -2124,6 +2129,7 @@ def cmd_v4_run(args):
     dry_run = getattr(args, 'dry_run', False)
     force_llm = getattr(args, 'force_llm', False)
     skip_verify = getattr(args, 'skip_verify', False)
+    force = getattr(args, 'force', False)
     num_windows = getattr(args, 'windows', 1)
 
     if not strategy_id and not run_all:
@@ -2172,7 +2178,7 @@ def cmd_v4_run(args):
         failed_count = sum(1 for r in results if not r.success)
         return 1 if failed_count > 0 else 0
     else:
-        result = runner.run(strategy_id, dry_run=dry_run, force_llm=force_llm, skip_verify=skip_verify)
+        result = runner.run(strategy_id, dry_run=dry_run, force_llm=force_llm, skip_verify=skip_verify, force=force)
 
         if not result.success:
             print(f"\nPipeline failed: {result.error}")

--- a/research_system/validation/v4_runner.py
+++ b/research_system/validation/v4_runner.py
@@ -113,6 +113,7 @@ class V4Runner:
         dry_run: bool = False,
         force_llm: bool = False,
         skip_verify: bool = False,
+        force: bool = False,
     ) -> V4RunResult:
         """Run the full pipeline for a single strategy.
 
@@ -121,6 +122,7 @@ class V4Runner:
             dry_run: If True, show what would happen without executing
             force_llm: Force LLM code generation instead of template
             skip_verify: If True, skip verification check
+            force: If True, re-run blocked strategies by moving them back to pending
 
         Returns:
             V4RunResult with pipeline outcome
@@ -139,12 +141,17 @@ class V4Runner:
 
         current_status = self._get_strategy_status(strategy_id)
         if current_status == "blocked":
-            return V4RunResult(
-                strategy_id=strategy_id,
-                success=False,
-                determination="BLOCKED",
-                error=f"Strategy is blocked",
-            )
+            if force:
+                print(f"  --force: Moving {strategy_id} from blocked to pending")
+                self._update_status(strategy_id, "pending")
+                self._reset_strategy_status(strategy_id)
+            else:
+                return V4RunResult(
+                    strategy_id=strategy_id,
+                    success=False,
+                    determination="BLOCKED",
+                    error=f"Strategy is blocked (use --force to retry)",
+                )
 
         # Step 1b: Run verification check (unless skipped)
         if not skip_verify and not dry_run:
@@ -411,6 +418,19 @@ class V4Runner:
                 logger.info(f"Moved {strategy_id} from {current_status} to {new_status}")
             except Exception as e:
                 logger.error(f"Failed to move strategy: {e}")
+
+    def _reset_strategy_status(self, strategy_id: str) -> None:
+        """Reset the status field inside the strategy YAML to 'pending'."""
+        path = self.workspace.strategies_path / "pending" / f"{strategy_id}.yaml"
+        if path.exists():
+            try:
+                data = yaml.safe_load(path.read_text())
+                if isinstance(data, dict) and data.get("status") != "pending":
+                    data["status"] = "pending"
+                    path.write_text(yaml.dump(data, default_flow_style=False))
+                    logger.info(f"Reset {strategy_id} YAML status to pending")
+            except Exception as e:
+                logger.error(f"Failed to reset strategy status: {e}")
 
     def _save_result(self, strategy_id: str, result: V4RunResult) -> None:
         """Save run result to validations directory."""


### PR DESCRIPTION
Fixes #178. Adds a --force flag to the run command that allows retrying strategies that were previously blocked due to transient errors.