### PR TITLE
fix: add missing v4 templates subpackage to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ research-codegen = "research_system.codegen.cli:main"
 "Bug Tracker" = "https://github.com/your-repo/research-kit/issues"
 
 [tool.setuptools]
-packages = ["research_system", "research_system.cli", "research_system.core", "research_system.core.v4", "research_system.ingest", "research_system.llm", "research_system.schemas", "research_system.schemas.v4", "research_system.db", "research_system.codegen", "research_system.codegen.templates", "research_system.validation", "agents", "agents.personas", "agents.prompts", "scripts", "scripts.validate", "scripts.utils", "scripts.data", "scripts.catalog", "scripts.backtest", "scripts.combinations", "scripts.status", "scripts.develop", "scripts.ingest"]
+packages = ["research_system", "research_system.cli", "research_system.core", "research_system.core.v4", "research_system.ingest", "research_system.llm", "research_system.schemas", "research_system.schemas.v4", "research_system.db", "research_system.codegen", "research_system.codegen.templates", "research_system.codegen.templates.v4", "research_system.validation", "agents", "agents.personas", "agents.prompts", "scripts", "scripts.validate", "scripts.utils", "scripts.data", "scripts.catalog", "scripts.backtest", "scripts.combinations", "scripts.status", "scripts.develop", "scripts.ingest"]
 include-package-data = true
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
## Summary
- Added `research_system.codegen.templates.v4` to the `packages` list in `pyproject.toml`, fixing an ImportError that would occur on non-editable installs
- Verified that `get_template_for_v4_strategy()` function signature (2 params: `strategy_type`, `signal_type`) already matches all call sites in `v4_generator.py` and `v4_runner.py` -- no code change needed there
- Confirmed no other `__init__.py` subdirectories under `research_system/codegen/templates/` are missing

## Test plan
- [x] `pip install -e .` succeeds
- [x] `python -c "from research_system.codegen.templates.v4 import get_template_for_v4_strategy; print('Import OK')"` passes
- [x] `python -m pytest tests/ tests_v2/ -k codegen -x` -- 102 passed
- [x] `research run --dry-run --force STRAT-001` runs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)