### PR TITLE
Downgrade works_all_conditions from hard to soft red flag

### DIFF
--- a/research_system/core/v4/config.py
+++ b/research_system/core/v4/config.py
@@ -181,7 +181,6 @@ class RedFlagsConfig(BaseModel):
         default_factory=lambda: [
             "sharpe_above_3",
             "no_losing_periods",
-            "works_all_conditions",
             "author_selling",
             "excessive_parameters",
             "convenient_start_date",
@@ -190,6 +189,7 @@ class RedFlagsConfig(BaseModel):
     )
     soft_warning: list[str] = Field(
         default_factory=lambda: [
+            "works_all_conditions",
             "unknown_rationale",
             "no_transaction_costs",
             "no_drawdown_mentioned",


### PR DESCRIPTION
## Summary

- Moves `works_all_conditions` from the `hard_reject` list to the `soft_warning` list in `RedFlagsConfig`
- Strategies flagged with `works_all_conditions` are now accepted with a warning instead of being auto-rejected
- Prevents false positive rejections of legitimate conditional strategies (Hindenberg Omen crash detector, dividend capture strategies)

Closes #198

## Test plan

- [x] All 74 config and schema tests pass (`tests/v4/test_config.py` and `tests/v4/test_schema.py`)
- [x] Pre-existing failures in `test_data_registry.py` and `test_llm_client.py` are unrelated to this change
- [ ] Re-ingest previously rejected files to verify they are now accepted with warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)