### PR TITLE
Add min_cagr validation gate

### DIFF
--- a/research_system/core/v4/config.py
+++ b/research_system/core/v4/config.py
@@ -69,6 +69,9 @@ class GatesConfig(BaseModel):
     max_drawdown: float = Field(
         0.25, ge=0, le=1.0, description="Maximum allowed drawdown (as decimal, e.g., 0.25 for 25%)"
     )
+    min_cagr: float = Field(
+        0.05, ge=0, description="Minimum CAGR required"
+    )
     min_trades: int = Field(
         30, ge=0, description="Minimum number of trades required"
     )

--- a/research_system/schemas/v4/validation.py
+++ b/research_system/schemas/v4/validation.py
@@ -102,6 +102,7 @@ class ValidationGates(BaseModel):
     min_sharpe: float = Field(0.5, description="Minimum Sharpe ratio")
     min_consistency: float = Field(0.6, description="Minimum consistency score")
     max_drawdown: float = Field(0.3, description="Maximum allowed drawdown")
+    min_cagr: float = Field(0.05, description="Minimum CAGR")
     min_trades: int = Field(30, description="Minimum number of trades")
 
     def check_sharpe(self, sharpe: float) -> bool:
@@ -115,6 +116,10 @@ class ValidationGates(BaseModel):
     def check_drawdown(self, drawdown: float) -> bool:
         """Check if drawdown is within threshold (drawdown should be positive)."""
         return drawdown <= self.max_drawdown
+
+    def check_cagr(self, cagr: float) -> bool:
+        """Check if CAGR meets threshold."""
+        return cagr >= self.min_cagr
 
     def check_trades(self, trades: int) -> bool:
         """Check if trade count meets threshold."""
@@ -227,6 +232,9 @@ class Validation(BaseModel):
 
         if self.results.max_drawdown is not None:
             checks.append(self.gates_applied.check_drawdown(self.results.max_drawdown))
+
+        if self.results.cagr is not None:
+            checks.append(self.gates_applied.check_cagr(self.results.cagr))
 
         if self.results.total_trades is not None:
             checks.append(self.gates_applied.check_trades(self.results.total_trades))

--- a/research_system/validation/backtest.py
+++ b/research_system/validation/backtest.py
@@ -106,6 +106,7 @@ class WalkForwardResult:
     mean_return: float | None = None
     median_return: float | None = None
     aggregate_sharpe: float | None = None
+    aggregate_cagr: float | None = None
     max_drawdown: float | None = None
     consistency: float | None = None  # % of profitable windows
     determination: str = "PENDING"  # VALIDATED, INVALIDATED, BLOCKED, RETRY_LATER
@@ -129,6 +130,7 @@ class WalkForwardResult:
             "mean_return": self.mean_return,
             "median_return": self.median_return,
             "aggregate_sharpe": self.aggregate_sharpe,
+            "aggregate_cagr": self.aggregate_cagr,
             "max_drawdown": self.max_drawdown,
             "consistency": self.consistency,
             "determination": self.determination,
@@ -527,6 +529,11 @@ class BacktestExecutor:
         sharpes = [w.result.sharpe for w in successful_windows if w.result.sharpe is not None]
         if sharpes:
             wf_result.aggregate_sharpe = sum(sharpes) / len(sharpes)
+
+        # Calculate aggregate CAGR (mean of all window CAGRs)
+        cagrs = [w.result.cagr for w in successful_windows if w.result.cagr is not None]
+        if cagrs:
+            wf_result.aggregate_cagr = sum(cagrs) / len(cagrs)
 
         # Max drawdown (worst across all windows)
         drawdowns = [w.result.max_drawdown for w in successful_windows if w.result.max_drawdown is not None]

--- a/research_system/validation/runner.py
+++ b/research_system/validation/runner.py
@@ -254,7 +254,8 @@ class Runner:
 
         # Print aggregates
         if wf_result.aggregate_sharpe is not None:
-            print(f"  Aggregate: Sharpe={wf_result.aggregate_sharpe:.2f}, Consistency={wf_result.consistency*100:.0f}%")
+            cagr_str = f", CAGR={wf_result.aggregate_cagr*100:.1f}%" if wf_result.aggregate_cagr is not None else ""
+            print(f"  Aggregate: Sharpe={wf_result.aggregate_sharpe:.2f}, Consistency={wf_result.consistency*100:.0f}%{cagr_str}")
             if wf_result.max_drawdown is not None:
                 print(f"             Max DD={wf_result.max_drawdown*100:.1f}%")
 
@@ -408,6 +409,15 @@ class Runner:
                 "passed": wf_result.max_drawdown <= config_gates.max_drawdown,
             })
 
+        # CAGR gate
+        if wf_result.aggregate_cagr is not None:
+            gates.append({
+                "gate": "min_cagr",
+                "threshold": config_gates.min_cagr,
+                "actual": wf_result.aggregate_cagr,
+                "passed": wf_result.aggregate_cagr >= config_gates.min_cagr,
+            })
+
         return gates
 
     def _update_status(self, strategy_id: str, new_status: str) -> None:
@@ -458,6 +468,7 @@ class Runner:
             yaml_data = {
                 "strategy_id": strategy_id,
                 "aggregate_sharpe": result.backtest.aggregate_sharpe,
+                "aggregate_cagr": result.backtest.aggregate_cagr,
                 "consistency": result.backtest.consistency,
                 "max_drawdown": result.backtest.max_drawdown,
                 "mean_return": result.backtest.mean_return,
@@ -504,6 +515,7 @@ class Runner:
         print(f"    min_sharpe: {config_gates.min_sharpe}")
         print(f"    min_consistency: {config_gates.min_consistency}")
         print(f"    max_drawdown: {config_gates.max_drawdown}")
+        print(f"    min_cagr: {config_gates.min_cagr}")
 
         print(f"  Walk-forward windows: {self.num_windows}")
         print(f"  Backtest mode: {'Local Docker' if self.use_local else 'QC Cloud'}")


### PR DESCRIPTION
## Summary
- Add `min_cagr` field (default 0.05) to `GatesConfig` and `ValidationGates`
- Compute `aggregate_cagr` (mean of window CAGRs) in `WalkForwardResult`
- Add CAGR gate check in `_apply_gates()` alongside existing sharpe/consistency/drawdown gates
- Update aggregate output printing and dry-run display to include CAGR
- Add tests for CAGR gate pass, fail, and None-skip cases

## Test plan
- [x] `test_gates_pass_with_good_metrics` updated to include aggregate_cagr and expect 4 gates
- [x] `test_gates_fail_low_cagr` verifies gate fails when CAGR < threshold
- [x] `test_gates_skip_cagr_when_none` verifies gate is omitted when aggregate_cagr is None
- [x] All 606 existing tests continue to pass (13 pre-existing failures unrelated)

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)