### PR TITLE
Reuse single QC cloud project to avoid 100/day limit

### DIFF
--- a/research_system/cli/main.py
+++ b/research_system/cli/main.py
@@ -1093,6 +1093,11 @@ Examples:
         help="Number of walk-forward windows: 1 (fastest), 2 (IS/OOS), or 5 (thorough). Default: 1"
     )
     parser.add_argument(
+        "--no-reuse-project",
+        action="store_true",
+        help="Create a new QC cloud project per backtest (legacy mode). Default reuses a single project to avoid 100/day limit."
+    )
+    parser.add_argument(
         "--workspace", "-w",
         dest="v4_workspace",
         metavar="PATH",
@@ -2312,6 +2317,8 @@ def cmd_run(args):
     skip_verify = getattr(args, 'skip_verify', False)
     force = getattr(args, 'force', False)
     num_windows = getattr(args, 'windows', 1)
+    no_reuse = getattr(args, 'no_reuse_project', False)
+    reuse_project = not no_reuse
 
     if not strategy_id and not run_all:
         print("Error: Strategy ID required or use --all")
@@ -2339,12 +2346,15 @@ def cmd_run(args):
         llm_client=llm_client,
         use_local=use_local,
         num_windows=num_windows,
+        reuse_project=reuse_project,
     )
 
     print("\n" + "=" * 60)
     print("  Validation Pipeline")
     print("=" * 60)
     print(f"\nBacktest mode: {'Local Docker' if use_local else 'QC Cloud'}")
+    if not use_local:
+        print(f"Project mode: {'reuse single project' if reuse_project else 'new project per backtest'}")
     print(f"Walk-forward windows: {num_windows}")
     if dry_run:
         print("[DRY RUN] No backtests will be executed")

--- a/research_system/validation/runner.py
+++ b/research_system/validation/runner.py
@@ -79,6 +79,7 @@ class Runner:
         llm_client=None,
         use_local: bool = False,
         num_windows: int = 1,
+        reuse_project: bool = True,
     ):
         """Initialize the V4 runner.
 
@@ -87,6 +88,7 @@ class Runner:
             llm_client: Optional LLM client for code generation
             use_local: Use local Docker instead of QC cloud
             num_windows: Number of walk-forward windows (1, 2, or 5)
+            reuse_project: Reuse a single QC cloud project (avoids 100/day limit)
         """
         self.workspace = workspace
         self.llm_client = llm_client
@@ -106,6 +108,7 @@ class Runner:
             cleanup_on_start=not use_local,
             num_windows=num_windows,
             timeout=self._config.backtest.timeout,
+            reuse_project=reuse_project,
         )
 
     def run(


### PR DESCRIPTION
## Summary
- Adds `reuse_project` mode (default: True for cloud) to `BacktestExecutor`
- Uses a fixed project directory (`validations/_runner/`) instead of creating unique dirs per backtest
- First `lean cloud backtest --push` creates the QC project; subsequent runs update and reuse it
- Legacy per-backtest project creation preserved via `--no-reuse-project` CLI flag
- 8 new tests covering reuse mode behavior

## Test plan
- [x] 594 tests passing (0 failures)
- [x] New tests verify: reuse enabled by default for cloud, disabled for local, fixed dir creation, main.py overwrite, no cleanup of runner dir, legacy mode creates unique dirs
- [ ] Live test: run `research run STRAT-XXX` and verify it reuses the `_runner` project on QC cloud

Fixes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)