### PR TITLE
Default to IS/OOS walk-forward validation (#206)

### DIFF
--- a/research_system/cli/main.py
+++ b/research_system/cli/main.py
@@ -1076,6 +1076,11 @@ Examples:
         help="Force LLM code generation instead of templates"
     )
     parser.add_argument(
+        "--skip-codegen",
+        action="store_true",
+        help="Skip code generation and use existing backtest.py (for hand-written ports)"
+    )
+    parser.add_argument(
         "--skip-verify",
         action="store_true",
         help="Skip verification check before running"
@@ -1088,9 +1093,9 @@ Examples:
     parser.add_argument(
         "--windows",
         type=int,
-        default=1,
+        default=2,
         choices=[1, 2, 5],
-        help="Number of walk-forward windows: 1 (fastest), 2 (IS/OOS), or 5 (thorough). Default: 1"
+        help="Number of walk-forward windows: 1 (single period), 2 (IS/OOS, default), or 5 (thorough). Default: 2"
     )
     parser.add_argument(
         "--no-reuse-project",
@@ -2315,6 +2320,7 @@ def cmd_run(args):
     dry_run = getattr(args, 'dry_run', False)
     force_llm = getattr(args, 'force_llm', False)
     skip_verify = getattr(args, 'skip_verify', False)
+    skip_codegen = getattr(args, 'skip_codegen', False)
     force = getattr(args, 'force', False)
     num_windows = getattr(args, 'windows', 1)
     no_reuse = getattr(args, 'no_reuse_project', False)
@@ -2361,7 +2367,7 @@ def cmd_run(args):
     print()
 
     if run_all:
-        results = runner.run_all(dry_run=dry_run, force_llm=force_llm, skip_verify=skip_verify)
+        results = runner.run_all(dry_run=dry_run, force_llm=force_llm, skip_verify=skip_verify, skip_codegen=skip_codegen)
         if not results:
             return 0
 
@@ -2369,7 +2375,7 @@ def cmd_run(args):
         failed_count = sum(1 for r in results if not r.success)
         return 1 if failed_count > 0 else 0
     else:
-        result = runner.run(strategy_id, dry_run=dry_run, force_llm=force_llm, skip_verify=skip_verify, force=force)
+        result = runner.run(strategy_id, dry_run=dry_run, force_llm=force_llm, skip_verify=skip_verify, force=force, skip_codegen=skip_codegen)
 
         if not result.success:
             print(f"\nPipeline failed: {result.error}")

--- a/research_system/core/v4/config.py
+++ b/research_system/core/v4/config.py
@@ -75,6 +75,9 @@ class GatesConfig(BaseModel):
     min_trades: int = Field(
         30, ge=0, description="Minimum number of trades required"
     )
+    min_window_pass_rate: float = Field(
+        0.8, ge=0, le=1.0, description="Minimum fraction of windows that must individually pass gates (for --windows 5)"
+    )
 
 
 class IngestionConfig(BaseModel):


### PR DESCRIPTION
## Summary
- Change default `--windows` from 1 (single period) to 2 (IS/OOS) so strategies must prove out-of-sample performance
- When using `--windows 2`, validation gates now evaluate the **OOS window only** (2018-2023), not the aggregate of IS+OOS
- Add `min_window_pass_rate` gate (default 0.8) for `--windows 5` mode - requires 4/5 individual windows to pass all gates
- Include `--skip-codegen` flag for hand-written QC strategy ports

## Files Changed
- `research_system/cli/main.py` - Default `--windows` from 1 to 2, `--skip-codegen` flag
- `research_system/core/v4/config.py` - Add `min_window_pass_rate` to GatesConfig
- `research_system/validation/backtest.py` - `ONE_WINDOW` constant, `_aggregate_oos_results()` method
- `research_system/validation/runner.py` - OOS gating logic, `_apply_window_consistency_gate()`, `--skip-codegen` support
- `tests/v4/test_v4_backtest.py` - OOS aggregation and default window tests
- `tests/v4/test_v4_runner.py` - Window consistency gate tests

## Test plan
- [x] All 59 v4 tests pass (0 failures)
- [x] Full suite: 639 passed, 10 pre-existing failures (unrelated unit tests)
- [ ] Manual: run validated strategies with `--windows 2` to verify OOS gating

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)