### PR TITLE
Strengthen validation gates: min_trades, Calmar, alpha

### DIFF
--- a/research_system/core/v4/config.py
+++ b/research_system/core/v4/config.py
@@ -75,6 +75,12 @@ class GatesConfig(BaseModel):
     min_trades: int = Field(
         30, ge=0, description="Minimum number of trades required"
     )
+    min_calmar: float = Field(
+        0.3, ge=0, description="Minimum Calmar ratio (CAGR / MaxDD) required"
+    )
+    min_alpha: float = Field(
+        0.0, description="Minimum alpha (benchmark-relative return) required"
+    )
     min_window_pass_rate: float = Field(
         0.8, ge=0, le=1.0, description="Minimum fraction of windows that must individually pass gates (for --windows 5)"
     )

--- a/research_system/validation/runner.py
+++ b/research_system/validation/runner.py
@@ -474,6 +474,36 @@ class Runner:
                 "passed": wf_result.aggregate_cagr >= config_gates.min_cagr,
             })
 
+        # Min trades gate
+        if wf_result.aggregate_total_trades is not None:
+            gates.append({
+                "gate": "min_trades",
+                "threshold": float(config_gates.min_trades),
+                "actual": float(wf_result.aggregate_total_trades),
+                "passed": wf_result.aggregate_total_trades >= config_gates.min_trades,
+            })
+
+        # Calmar ratio gate (CAGR / MaxDD)
+        if (wf_result.aggregate_cagr is not None
+                and wf_result.max_drawdown is not None
+                and wf_result.max_drawdown > 0):
+            calmar = wf_result.aggregate_cagr / wf_result.max_drawdown
+            gates.append({
+                "gate": "min_calmar",
+                "threshold": config_gates.min_calmar,
+                "actual": calmar,
+                "passed": calmar >= config_gates.min_calmar,
+            })
+
+        # Alpha gate (benchmark-relative)
+        if wf_result.aggregate_alpha is not None:
+            gates.append({
+                "gate": "min_alpha",
+                "threshold": config_gates.min_alpha,
+                "actual": wf_result.aggregate_alpha,
+                "passed": wf_result.aggregate_alpha >= config_gates.min_alpha,
+            })
+
         return gates
 
     def _apply_window_consistency_gate(self, wf_result: WalkForwardResult) -> dict[str, Any] | None:


### PR DESCRIPTION
## Summary
- Fix min_trades gate bug: config field existed but was never enforced in `_apply_gates()`
- Add `aggregate_total_trades` and `aggregate_alpha` to `WalkForwardResult` with proper aggregation in both walk-forward and IS/OOS modes
- Add Calmar ratio gate (`min_calmar`: CAGR/MaxDD > 0.3) to catch poor return-per-drawdown
- Add alpha gate (`min_alpha`: benchmark-relative return > 0) to filter sub-benchmark strategies
- 9 new tests covering pass, fail, and skip-when-None cases for all 3 gates

## Test plan
- [x] All 38 v4 runner tests pass (`pytest tests/v4/test_v4_runner.py -v`)
- [x] New gate tests: min_trades (3), calmar (4), alpha (3)
- [x] Existing test updated to account for new Calmar gate in gate count

🤖 Generated with [Claude Code](https://claude.com/claude-code)