### PR TITLE
Capture equity curves from QC backtest results

### DIFF
--- a/research_system/validation/backtest.py
+++ b/research_system/validation/backtest.py
@@ -68,6 +68,7 @@ class BacktestResult:
     raw_output: str | None = None
     rate_limited: bool = False
     engine_crash: bool = False
+    equity_curve: dict[str, Any] | None = None  # {"dates": [...], "equity": [...]}
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for serialization."""
@@ -84,6 +85,7 @@ class BacktestResult:
             "error": self.error,
             "rate_limited": self.rate_limited,
             "engine_crash": self.engine_crash,
+            "equity_curve": self.equity_curve,
         }
 
 
@@ -831,9 +833,13 @@ class BacktestExecutor:
         # Try to get results from QC API
         project_id, backtest_id = self._extract_backtest_ids(stdout)
         if project_id and backtest_id:
-            stats = self._fetch_backtest_stats(project_id, backtest_id)
-            if stats:
-                return self._parse_stats(stats, stdout)
+            backtest_data = self._fetch_backtest_data(project_id, backtest_id)
+            if backtest_data:
+                stats = backtest_data.get("statistics", {})
+                if stats:
+                    result = self._parse_stats(stats, stdout)
+                    result.equity_curve = self._extract_equity_curve(backtest_data)
+                    return result
 
         # Fallback to table parsing
         return self._parse_lean_output_table(stdout)
@@ -1040,6 +1046,55 @@ class BacktestExecutor:
         if data and data.get("success"):
             return data.get("backtest", {}).get("statistics", {})
         return None
+
+    def _fetch_backtest_data(self, project_id: str, backtest_id: str) -> dict[str, Any] | None:
+        """Fetch full backtest data including equity curve from QC API."""
+        data = self._qc_api_request("backtests/read", {"projectId": project_id, "backtestId": backtest_id})
+        if data and data.get("success"):
+            return data.get("backtest", {})
+        return None
+
+    @staticmethod
+    def _extract_equity_curve(backtest_data: dict[str, Any]) -> dict[str, Any] | None:
+        """Extract monthly equity curve from QC rolling window data.
+
+        The QC API returns a rollingWindow with M1_YYYYMMDD entries containing
+        monthly portfolio statistics including endEquity values.
+        """
+        rolling_window = backtest_data.get("rollingWindow", {})
+        if not rolling_window:
+            return None
+
+        # Extract M1 (1-month) entries which contain month-end equity values
+        monthly_entries = sorted(
+            [(k, v) for k, v in rolling_window.items() if k.startswith("M1_")],
+            key=lambda x: x[0],
+        )
+
+        if not monthly_entries:
+            return None
+
+        dates = []
+        equity = []
+        for key, entry in monthly_entries:
+            # Key format: M1_YYYYMMDD
+            date_str = key[3:]  # Remove "M1_" prefix
+            date_formatted = f"{date_str[:4]}-{date_str[4:6]}-{date_str[6:]}"
+
+            portfolio_stats = entry.get("portfolioStatistics", {})
+            end_equity = portfolio_stats.get("endEquity")
+
+            if end_equity is not None:
+                try:
+                    dates.append(date_formatted)
+                    equity.append(float(end_equity))
+                except (ValueError, TypeError):
+                    continue
+
+        if not dates:
+            return None
+
+        return {"dates": dates, "equity": equity}
 
     def _list_project_backtests(self, project_id: str) -> list[dict[str, Any]]:
         """List all backtests for a project."""

--- a/research_system/validation/runner.py
+++ b/research_system/validation/runner.py
@@ -613,6 +613,17 @@ class Runner:
             }
             backtest_file.write_text(yaml.dump(yaml_data, default_flow_style=False))
 
+            # Save equity curves for each window (for portfolio correlation analysis)
+            for w in result.backtest.windows:
+                if w.result.equity_curve:
+                    curve_file = val_dir / f"equity_curve_w{w.window_id}.json"
+                    curve_file.write_text(json.dumps({
+                        "strategy_id": strategy_id,
+                        "window_id": w.window_id,
+                        "period": f"{w.start_date} to {w.end_date}",
+                        "equity_curve": w.result.equity_curve,
+                    }, indent=2))
+
     def _dry_run(self, strategy_id: str, strategy: dict[str, Any]) -> RunResult:
         """Show what would happen without executing."""
         # V4 schema: tags.hypothesis_type (list), entry.type, hypothesis.summary


### PR DESCRIPTION
## Summary
- Extract monthly equity values from QC API `rollingWindow` data after each backtest
- Add `equity_curve` field to `BacktestResult` dataclass
- Save `equity_curve_w{N}.json` per window in the validation directory
- Enables portfolio correlation analysis across validated strategies

## Changes
- `backtest.py`: Added `_fetch_backtest_data()` and `_extract_equity_curve()` methods; modified `_parse_lean_output()` to capture equity curves from the existing QC API call
- `runner.py`: Save equity curve JSON files alongside existing result files

## Test plan
- [x] Unit tests: BacktestResult serialization, equity curve extraction, edge cases (empty data, no M1 entries)
- [x] Existing test suite: 110 backtest/validation tests pass
- [ ] Integration: Re-run a validated strategy and verify equity_curve_w{N}.json is created

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)