### PR TITLE
feat: add research explore commands for managing deep research efforts

### DIFF
--- a/research_system/cli/main.py
+++ b/research_system/cli/main.py
@@ -1344,6 +1344,109 @@ Configuration includes:
     )
     parser.set_defaults(func=cmd_config)
 
+    # explore-init command
+    parser = subparsers.add_parser(
+        "explore-init",
+        help="Initialize a new research effort",
+        description="""
+Create a new research effort directory under research/.
+
+Creates:
+  research/{topic-slug}/
+  ├── research.yaml
+  └── RESEARCH_PLAN.md
+
+Examples:
+  research explore-init "Regime-Conditioned Options" --tags options,regime
+  research explore-init "FX Carry Signal"
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "title",
+        help="Title of the research effort (e.g., 'Regime-Conditioned Options')"
+    )
+    parser.add_argument(
+        "--tags",
+        default="",
+        help="Comma-separated tags (e.g., options,regime)"
+    )
+    parser.add_argument(
+        "--workspace", "-w",
+        dest="v4_workspace",
+        metavar="PATH",
+        help="Path to workspace"
+    )
+    parser.set_defaults(func=cmd_explore_init)
+
+    # explore-list command
+    parser = subparsers.add_parser(
+        "explore-list",
+        help="List all research efforts",
+        description="""
+Scan research/ for all directories containing research.yaml and display a table.
+
+Use --index to also write an INDEX.md file for browsing.
+
+Examples:
+  research explore-list
+  research explore-list --index
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--index",
+        action="store_true",
+        help="Also write research/INDEX.md"
+    )
+    parser.add_argument(
+        "--workspace", "-w",
+        dest="v4_workspace",
+        metavar="PATH",
+        help="Path to workspace"
+    )
+    parser.set_defaults(func=cmd_explore_list)
+
+    # explore-update command
+    parser = subparsers.add_parser(
+        "explore-update",
+        help="Update a research effort",
+        description="""
+Update fields in an existing research effort's research.yaml.
+
+Examples:
+  research explore-update regime-options --status complete
+  research explore-update fx-signal --strategy STRAT-277
+  research explore-update regime-options --tag volatility
+  research explore-update regime-options --status complete --strategy STRAT-310
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "topic",
+        help="Topic slug of the research effort (e.g., regime-options)"
+    )
+    parser.add_argument(
+        "--status",
+        choices=["active", "paused", "complete", "archived"],
+        help="Set status (active, paused, complete, archived)"
+    )
+    parser.add_argument(
+        "--strategy",
+        help="Append a strategy ID to strategies_produced (e.g., STRAT-306)"
+    )
+    parser.add_argument(
+        "--tag",
+        help="Append a tag"
+    )
+    parser.add_argument(
+        "--workspace", "-w",
+        dest="v4_workspace",
+        metavar="PATH",
+        help="Path to workspace"
+    )
+    parser.set_defaults(func=cmd_explore_update)
+
 
 # ============================================================================
 # Command Implementations
@@ -4940,6 +5043,290 @@ def _check_multiple_installations():
     except Exception:
         # Best-effort — never let this break the CLI
         pass
+
+
+# ============================================================================
+# Explore Commands (Research Effort Management)
+# ============================================================================
+
+
+def _slugify(title: str) -> str:
+    """Convert a title to a topic slug (lowercase, hyphenated).
+
+    Examples:
+        "Regime-Conditioned Options" -> "regime-conditioned-options"
+        "FX Carry Signal" -> "fx-carry-signal"
+        "Hello   World!!!" -> "hello-world"
+    """
+    import re
+    slug = title.lower().strip()
+    # Replace any non-alphanumeric characters (except hyphens) with hyphens
+    slug = re.sub(r'[^a-z0-9-]+', '-', slug)
+    # Collapse multiple hyphens
+    slug = re.sub(r'-+', '-', slug)
+    # Strip leading/trailing hyphens
+    slug = slug.strip('-')
+    return slug
+
+
+def _load_research_yaml(path: Path) -> dict:
+    """Load a research.yaml file."""
+    import yaml
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+def _save_research_yaml(path: Path, data: dict) -> None:
+    """Save a research.yaml file."""
+    import yaml
+    with open(path, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+
+def cmd_explore_init(args):
+    """Initialize a new research effort."""
+    import yaml
+
+    workspace = get_workspace_from_args(args)
+
+    try:
+        workspace.require_initialized()
+    except V4WorkspaceError as e:
+        print(f"Error: {e}")
+        print("Run 'research init' to initialize a workspace.")
+        return 1
+
+    title = args.title
+    topic = _slugify(title)
+
+    if not topic:
+        print("Error: Title must contain at least one alphanumeric character.")
+        return 1
+
+    tags = [t.strip() for t in args.tags.split(",") if t.strip()] if args.tags else []
+
+    research_dir = workspace.research_path / topic
+
+    if research_dir.exists():
+        print(f"Error: Research effort '{topic}' already exists at {research_dir}")
+        return 1
+
+    # Create directory
+    research_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create research.yaml
+    research_data = {
+        "topic": topic,
+        "title": title,
+        "status": "active",
+        "tags": tags,
+        "strategies_produced": [],
+    }
+    _save_research_yaml(research_dir / "research.yaml", research_data)
+
+    # Create RESEARCH_PLAN.md
+    plan_content = f"""# {title}
+
+## Hypothesis
+[What we believe and why]
+
+## Edge Rationale
+[Why this edge might exist, who is the counterparty]
+
+## Risks
+[Why it might not work]
+
+## Data Inventory
+[What we have, what we need]
+
+## Phases
+
+### Phase 1: [Name]
+- **Status:** TODO
+- **Findings:**
+
+## Strategy Implications
+[Links back to STRAT-XXX development]
+"""
+    with open(research_dir / "RESEARCH_PLAN.md", "w") as f:
+        f.write(plan_content)
+
+    print(f"Created research effort: {topic}")
+    print(f"  Directory: {research_dir}")
+    print(f"  research.yaml: {research_dir / 'research.yaml'}")
+    print(f"  RESEARCH_PLAN.md: {research_dir / 'RESEARCH_PLAN.md'}")
+    return 0
+
+
+def _scan_research_efforts(workspace) -> list[dict]:
+    """Scan research/ for all directories containing research.yaml.
+
+    Returns list of research effort data dicts, sorted by topic name.
+    """
+    efforts = []
+    research_dir = workspace.research_path
+
+    if not research_dir.exists():
+        return efforts
+
+    for d in sorted(research_dir.iterdir()):
+        if not d.is_dir():
+            continue
+        yaml_path = d / "research.yaml"
+        if not yaml_path.exists():
+            continue
+        try:
+            data = _load_research_yaml(yaml_path)
+            efforts.append(data)
+        except Exception:
+            # Skip malformed files
+            continue
+
+    return efforts
+
+
+def cmd_explore_list(args):
+    """List all research efforts."""
+    workspace = get_workspace_from_args(args)
+
+    try:
+        workspace.require_initialized()
+    except V4WorkspaceError as e:
+        print(f"Error: {e}")
+        print("Run 'research init' to initialize a workspace.")
+        return 1
+
+    efforts = _scan_research_efforts(workspace)
+
+    if not efforts:
+        print("No research efforts found.")
+        print("Use 'research explore-init \"Title\"' to create one.")
+        return 0
+
+    # Print table
+    print("Research Efforts:")
+    # Calculate column widths
+    topic_w = max(len(e.get("topic", "")) for e in efforts)
+    topic_w = max(topic_w, 5)  # minimum width
+    status_w = max(len(e.get("status", "")) for e in efforts)
+    status_w = max(status_w, 6)
+
+    header_topic = "Topic".ljust(topic_w)
+    header_status = "Status".ljust(status_w)
+
+    print(f"  {header_topic}  {header_status}  {'Tags':<24}  Strategies")
+
+    for e in efforts:
+        topic = e.get("topic", "").ljust(topic_w)
+        status = e.get("status", "").ljust(status_w)
+        tags = ", ".join(e.get("tags", []))
+        if len(tags) > 24:
+            tags = tags[:21] + "..."
+        tags = tags.ljust(24)
+        strategies = e.get("strategies_produced", [])
+        if strategies:
+            strat_str = ", ".join(
+                s.replace("STRAT-", "S") if s.startswith("STRAT-") else s
+                for s in strategies
+            )
+        else:
+            strat_str = "\u2014"
+        print(f"  {topic}  {status}  {tags}  {strat_str}")
+
+    # Write INDEX.md if requested
+    write_index = getattr(args, 'index', False)
+    if write_index:
+        _write_research_index(workspace, efforts)
+
+    return 0
+
+
+def _write_research_index(workspace, efforts: list[dict]) -> None:
+    """Write research/INDEX.md."""
+    lines = ["# Research Index", ""]
+    lines.append("| Topic | Title | Status | Tags | Strategies |")
+    lines.append("|-------|-------|--------|------|------------|")
+
+    for e in efforts:
+        topic = e.get("topic", "")
+        title = e.get("title", "")
+        status = e.get("status", "")
+        tags = ", ".join(e.get("tags", []))
+        strategies = e.get("strategies_produced", [])
+        strat_str = ", ".join(strategies) if strategies else "\u2014"
+        plan_link = f"[{topic}]({topic}/RESEARCH_PLAN.md)"
+        lines.append(f"| {plan_link} | {title} | {status} | {tags} | {strat_str} |")
+
+    lines.append("")
+    lines.append("*Auto-generated by `research explore-list --index`*")
+    lines.append("")
+
+    index_path = workspace.research_path / "INDEX.md"
+    with open(index_path, "w") as f:
+        f.write("\n".join(lines))
+
+    print(f"\nWrote {index_path}")
+
+
+def cmd_explore_update(args):
+    """Update a research effort."""
+    workspace = get_workspace_from_args(args)
+
+    try:
+        workspace.require_initialized()
+    except V4WorkspaceError as e:
+        print(f"Error: {e}")
+        print("Run 'research init' to initialize a workspace.")
+        return 1
+
+    topic = args.topic
+    new_status = getattr(args, 'status', None)
+    new_strategy = getattr(args, 'strategy', None)
+    new_tag = getattr(args, 'tag', None)
+
+    if not new_status and not new_strategy and not new_tag:
+        print("Error: At least one update flag required (--status, --strategy, or --tag)")
+        return 1
+
+    yaml_path = workspace.research_path / topic / "research.yaml"
+
+    if not yaml_path.exists():
+        print(f"Error: Research effort '{topic}' not found at {workspace.research_path / topic}")
+        return 1
+
+    data = _load_research_yaml(yaml_path)
+
+    changes = []
+
+    if new_status:
+        data["status"] = new_status
+        changes.append(f"status -> {new_status}")
+
+    if new_strategy:
+        strategies = data.get("strategies_produced", [])
+        if new_strategy not in strategies:
+            strategies.append(new_strategy)
+            data["strategies_produced"] = strategies
+            changes.append(f"added strategy {new_strategy}")
+        else:
+            changes.append(f"strategy {new_strategy} already present")
+
+    if new_tag:
+        tags = data.get("tags", [])
+        if new_tag not in tags:
+            tags.append(new_tag)
+            data["tags"] = tags
+            changes.append(f"added tag '{new_tag}'")
+        else:
+            changes.append(f"tag '{new_tag}' already present")
+
+    _save_research_yaml(yaml_path, data)
+
+    print(f"Updated {topic}:")
+    for change in changes:
+        print(f"  {change}")
+
+    return 0
 
 
 # ============================================================================

--- a/research_system/core/v4/workspace.py
+++ b/research_system/core/v4/workspace.py
@@ -108,6 +108,7 @@ class Workspace:
         "personas",
         "archive",
         "logs",
+        "research",
     ]
 
     VALID_STATUSES = {"pending", "validated", "invalidated", "blocked"}
@@ -404,6 +405,11 @@ class Workspace:
         return self.path / "logs"
 
     @property
+    def research_path(self) -> Path:
+        """Path to research efforts directory."""
+        return self.path / "research"
+
+    @property
     def state_path(self) -> Path:
         """Path to internal state directory."""
         return self.path / STATE_DIR
@@ -514,6 +520,14 @@ class Workspace:
             if f.is_file() and not f.name.startswith(".")
         ]) if self.inbox_path.exists() else 0
 
+        # Count research efforts (directories containing research.yaml)
+        research_count = 0
+        if self.research_path.exists():
+            research_count = len([
+                d for d in self.research_path.iterdir()
+                if d.is_dir() and (d / "research.yaml").exists()
+            ])
+
         # Get counters
         counters = self._read_counters()
 
@@ -523,6 +537,7 @@ class Workspace:
             "ideas": idea_count,
             "validations": validation_count,
             "inbox_files": inbox_count,
+            "research_efforts": research_count,
             "counters": counters,
         }
 

--- a/tests/v4/test_explore.py
+++ b/tests/v4/test_explore.py
@@ -1,0 +1,618 @@
+"""Tests for explore commands (research effort management).
+
+Tests:
+1. explore-init creates directory + files with correct content
+2. explore-init errors on existing directory
+3. explore-init slugifies title correctly
+4. explore-list finds efforts and formats output
+5. explore-list --index writes INDEX.md
+6. explore-update modifies research.yaml correctly
+7. explore-update appends strategy without duplicates
+8. explore-update errors on missing topic
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from research_system.core.v4 import Workspace
+
+
+# ============================================================================
+# Helper: create initialized workspace
+# ============================================================================
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    """Create an initialized workspace for testing."""
+    ws = Workspace(tmp_path)
+    ws.init()
+    return ws
+
+
+# ============================================================================
+# Slugify
+# ============================================================================
+
+
+class TestSlugify:
+    """Test the _slugify helper."""
+
+    def test_basic_title(self):
+        from research_system.cli.main import _slugify
+        assert _slugify("Regime-Conditioned Options") == "regime-conditioned-options"
+
+    def test_spaces_to_hyphens(self):
+        from research_system.cli.main import _slugify
+        assert _slugify("FX Carry Signal") == "fx-carry-signal"
+
+    def test_special_characters(self):
+        from research_system.cli.main import _slugify
+        assert _slugify("Hello   World!!!") == "hello-world"
+
+    def test_leading_trailing_whitespace(self):
+        from research_system.cli.main import _slugify
+        assert _slugify("  some title  ") == "some-title"
+
+    def test_already_slug(self):
+        from research_system.cli.main import _slugify
+        assert _slugify("already-a-slug") == "already-a-slug"
+
+    def test_numbers_preserved(self):
+        from research_system.cli.main import _slugify
+        assert _slugify("Phase 2 Analysis") == "phase-2-analysis"
+
+    def test_empty_string(self):
+        from research_system.cli.main import _slugify
+        assert _slugify("") == ""
+
+    def test_only_special_chars(self):
+        from research_system.cli.main import _slugify
+        assert _slugify("!!!") == ""
+
+
+# ============================================================================
+# explore-init
+# ============================================================================
+
+
+class TestExploreInit:
+    """Test explore-init command."""
+
+    def test_creates_directory_and_files(self, workspace):
+        """Test that explore-init creates the directory, research.yaml, and RESEARCH_PLAN.md."""
+        from research_system.cli.main import cmd_explore_init
+        import argparse
+
+        args = argparse.Namespace(
+            title="Regime-Conditioned Options",
+            tags="options,regime",
+            v4_workspace=str(workspace.path),
+            workspace=None,
+        )
+        result = cmd_explore_init(args)
+        assert result == 0
+
+        research_dir = workspace.research_path / "regime-conditioned-options"
+        assert research_dir.exists()
+        assert (research_dir / "research.yaml").exists()
+        assert (research_dir / "RESEARCH_PLAN.md").exists()
+
+    def test_research_yaml_content(self, workspace):
+        """Test that research.yaml has the correct fields."""
+        from research_system.cli.main import cmd_explore_init
+        import argparse
+
+        args = argparse.Namespace(
+            title="FX Carry Signal",
+            tags="fx,carry",
+            v4_workspace=str(workspace.path),
+            workspace=None,
+        )
+        cmd_explore_init(args)
+
+        yaml_path = workspace.research_path / "fx-carry-signal" / "research.yaml"
+        with open(yaml_path) as f:
+            data = yaml.safe_load(f)
+
+        assert data["topic"] == "fx-carry-signal"
+        assert data["title"] == "FX Carry Signal"
+        assert data["status"] == "active"
+        assert data["tags"] == ["fx", "carry"]
+        assert data["strategies_produced"] == []
+
+    def test_research_plan_content(self, workspace):
+        """Test that RESEARCH_PLAN.md has the expected template."""
+        from research_system.cli.main import cmd_explore_init
+        import argparse
+
+        args = argparse.Namespace(
+            title="Volatility Surface",
+            tags="",
+            v4_workspace=str(workspace.path),
+            workspace=None,
+        )
+        cmd_explore_init(args)
+
+        plan_path = workspace.research_path / "volatility-surface" / "RESEARCH_PLAN.md"
+        content = plan_path.read_text()
+
+        assert "# Volatility Surface" in content
+        assert "## Hypothesis" in content
+        assert "## Edge Rationale" in content
+        assert "## Risks" in content
+        assert "## Data Inventory" in content
+        assert "## Phases" in content
+        assert "### Phase 1:" in content
+        assert "## Strategy Implications" in content
+
+    def test_no_tags(self, workspace):
+        """Test creating research effort without tags."""
+        from research_system.cli.main import cmd_explore_init
+        import argparse
+
+        args = argparse.Namespace(
+            title="No Tags Research",
+            tags="",
+            v4_workspace=str(workspace.path),
+            workspace=None,
+        )
+        result = cmd_explore_init(args)
+        assert result == 0
+
+        yaml_path = workspace.research_path / "no-tags-research" / "research.yaml"
+        with open(yaml_path) as f:
+            data = yaml.safe_load(f)
+        assert data["tags"] == []
+
+    def test_error_on_existing_directory(self, workspace):
+        """Test that explore-init errors when directory already exists."""
+        from research_system.cli.main import cmd_explore_init
+        import argparse
+
+        args = argparse.Namespace(
+            title="Duplicate Topic",
+            tags="",
+            v4_workspace=str(workspace.path),
+            workspace=None,
+        )
+        # Create first
+        result = cmd_explore_init(args)
+        assert result == 0
+
+        # Attempt to create again
+        result = cmd_explore_init(args)
+        assert result == 1
+
+    def test_error_on_empty_title(self, workspace):
+        """Test that explore-init errors when title has no alphanumeric chars."""
+        from research_system.cli.main import cmd_explore_init
+        import argparse
+
+        args = argparse.Namespace(
+            title="!!!",
+            tags="",
+            v4_workspace=str(workspace.path),
+            workspace=None,
+        )
+        result = cmd_explore_init(args)
+        assert result == 1
+
+
+# ============================================================================
+# explore-list
+# ============================================================================
+
+
+class TestExploreList:
+    """Test explore-list command."""
+
+    def _create_effort(self, workspace, topic, title, status="active", tags=None, strategies=None):
+        """Helper to create a research effort directly."""
+        research_dir = workspace.research_path / topic
+        research_dir.mkdir(parents=True, exist_ok=True)
+        data = {
+            "topic": topic,
+            "title": title,
+            "status": status,
+            "tags": tags or [],
+            "strategies_produced": strategies or [],
+        }
+        with open(research_dir / "research.yaml", "w") as f:
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+    def test_list_empty(self, workspace, capsys):
+        """Test listing when no research efforts exist."""
+        from research_system.cli.main import cmd_explore_list
+        import argparse
+
+        args = argparse.Namespace(
+            index=False,
+            v4_workspace=str(workspace.path),
+            workspace=None,
+        )
+        result = cmd_explore_list(args)
+        assert result == 0
+
+        captured = capsys.readouterr()
+        assert "No research efforts found" in captured.out
+
+    def test_list_finds_efforts(self, workspace, capsys):
+        """Test that explore-list finds and displays research efforts."""
+        from research_system.cli.main import cmd_explore_list
+        import argparse
+
+        self._create_effort(workspace, "regime-options", "Regime Options", "complete",
+                           tags=["options", "regime"], strategies=["STRAT-306", "STRAT-310"])
+        self._create_effort(workspace, "fx-signal", "FX Signal", "paused",
+                           tags=["fx"], strategies=["STRAT-277"])
+
+        args = argparse.Namespace(
+            index=False,
+            v4_workspace=str(workspace.path),
+            workspace=None,
+        )
+        result = cmd_explore_list(args)
+        assert result == 0
+
+        captured = capsys.readouterr()
+        assert "Research Efforts:" in captured.out
+        assert "regime-options" in captured.out
+        assert "fx-signal" in captured.out
+        assert "complete" in captured.out
+        assert "paused" in captured.out
+
+    def test_list_strategies_displayed(self, workspace, capsys):
+        """Test that strategies are displayed with S prefix shorthand."""
+        from research_system.cli.main import cmd_explore_list
+        import argparse
+
+        self._create_effort(workspace, "test-topic", "Test", strategies=["STRAT-100", "STRAT-200"])
+
+        args = argparse.Namespace(
+            index=False,
+            v4_workspace=str(workspace.path),
+            workspace=None,
+        )
+        cmd_explore_list(args)
+
+        captured = capsys.readouterr()
+        assert "S100" in captured.out
+        assert "S200" in captured.out
+
+    def test_list_no_strategies_shows_dash(self, workspace, capsys):
+        """Test that no strategies shows em-dash."""
+        from research_system.cli.main import cmd_explore_list
+        import argparse
+
+        self._create_effort(workspace, "empty-topic", "Empty", strategies=[])
+
+        args = argparse.Namespace(
+            index=False,
+            v4_workspace=str(workspace.path),
+            workspace=None,
+        )
+        cmd_explore_list(args)
+
+        captured = capsys.readouterr()
+        assert "\u2014" in captured.out
+
+    def test_list_index_writes_file(self, workspace):
+        """Test that --index writes INDEX.md."""
+        from research_system.cli.main import cmd_explore_list
+        import argparse
+
+        self._create_effort(workspace, "regime-options", "Regime-Conditioned Options", "complete",
+                           tags=["options", "regime"], strategies=["STRAT-306", "STRAT-310"])
+        self._create_effort(workspace, "fx-signal", "FX Signal", "paused",
+                           tags=["fx"])
+
+        args = argparse.Namespace(
+            index=True,
+            v4_workspace=str(workspace.path),
+            workspace=None,
+        )
+        result = cmd_explore_list(args)
+        assert result == 0
+
+        index_path = workspace.research_path / "INDEX.md"
+        assert index_path.exists()
+
+        content = index_path.read_text()
+        assert "# Research Index" in content
+        assert "regime-options" in content
+        assert "fx-signal" in content
+        assert "Regime-Conditioned Options" in content
+        assert "STRAT-306" in content
+        assert "Auto-generated" in content
+
+    def test_index_contains_links(self, workspace):
+        """Test that INDEX.md contains links to RESEARCH_PLAN.md."""
+        from research_system.cli.main import cmd_explore_list
+        import argparse
+
+        self._create_effort(workspace, "my-topic", "My Topic", "active")
+
+        args = argparse.Namespace(
+            index=True,
+            v4_workspace=str(workspace.path),
+            workspace=None,
+        )
+        cmd_explore_list(args)
+
+        content = (workspace.research_path / "INDEX.md").read_text()
+        assert "[my-topic](my-topic/RESEARCH_PLAN.md)" in content
+
+    def test_list_ignores_dirs_without_yaml(self, workspace, capsys):
+        """Test that directories without research.yaml are ignored."""
+        from research_system.cli.main import cmd_explore_list
+        import argparse
+
+        # Create a directory without research.yaml
+        (workspace.research_path / "random-dir").mkdir(parents=True)
+        self._create_effort(workspace, "real-effort", "Real Effort")
+
+        args = argparse.Namespace(
+            index=False,
+            v4_workspace=str(workspace.path),
+            workspace=None,
+        )
+        cmd_explore_list(args)
+
+        captured = capsys.readouterr()
+        assert "real-effort" in captured.out
+        assert "random-dir" not in captured.out
+
+
+# ============================================================================
+# explore-update
+# ============================================================================
+
+
+class TestExploreUpdate:
+    """Test explore-update command."""
+
+    def _create_effort(self, workspace, topic, title="Test", status="active",
+                       tags=None, strategies=None):
+        """Helper to create a research effort directly."""
+        research_dir = workspace.research_path / topic
+        research_dir.mkdir(parents=True, exist_ok=True)
+        data = {
+            "topic": topic,
+            "title": title,
+            "status": status,
+            "tags": tags or [],
+            "strategies_produced": strategies or [],
+        }
+        with open(research_dir / "research.yaml", "w") as f:
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+    def test_update_status(self, workspace):
+        """Test updating status."""
+        from research_system.cli.main import cmd_explore_update
+        import argparse
+
+        self._create_effort(workspace, "my-topic")
+
+        args = argparse.Namespace(
+            topic="my-topic",
+            status="complete",
+            strategy=None,
+            tag=None,
+            v4_workspace=str(workspace.path),
+            workspace=None,
+        )
+        result = cmd_explore_update(args)
+        assert result == 0
+
+        with open(workspace.research_path / "my-topic" / "research.yaml") as f:
+            data = yaml.safe_load(f)
+        assert data["status"] == "complete"
+
+    def test_update_add_strategy(self, workspace):
+        """Test appending a strategy."""
+        from research_system.cli.main import cmd_explore_update
+        import argparse
+
+        self._create_effort(workspace, "my-topic", strategies=["STRAT-100"])
+
+        args = argparse.Namespace(
+            topic="my-topic",
+            status=None,
+            strategy="STRAT-200",
+            tag=None,
+            v4_workspace=str(workspace.path),
+            workspace=None,
+        )
+        result = cmd_explore_update(args)
+        assert result == 0
+
+        with open(workspace.research_path / "my-topic" / "research.yaml") as f:
+            data = yaml.safe_load(f)
+        assert "STRAT-200" in data["strategies_produced"]
+        assert "STRAT-100" in data["strategies_produced"]
+
+    def test_update_strategy_no_duplicate(self, workspace, capsys):
+        """Test that adding an existing strategy doesn't duplicate."""
+        from research_system.cli.main import cmd_explore_update
+        import argparse
+
+        self._create_effort(workspace, "my-topic", strategies=["STRAT-100"])
+
+        args = argparse.Namespace(
+            topic="my-topic",
+            status=None,
+            strategy="STRAT-100",
+            tag=None,
+            v4_workspace=str(workspace.path),
+            workspace=None,
+        )
+        result = cmd_explore_update(args)
+        assert result == 0
+
+        with open(workspace.research_path / "my-topic" / "research.yaml") as f:
+            data = yaml.safe_load(f)
+        assert data["strategies_produced"].count("STRAT-100") == 1
+
+        captured = capsys.readouterr()
+        assert "already present" in captured.out
+
+    def test_update_add_tag(self, workspace):
+        """Test appending a tag."""
+        from research_system.cli.main import cmd_explore_update
+        import argparse
+
+        self._create_effort(workspace, "my-topic", tags=["options"])
+
+        args = argparse.Namespace(
+            topic="my-topic",
+            status=None,
+            strategy=None,
+            tag="regime",
+            v4_workspace=str(workspace.path),
+            workspace=None,
+        )
+        result = cmd_explore_update(args)
+        assert result == 0
+
+        with open(workspace.research_path / "my-topic" / "research.yaml") as f:
+            data = yaml.safe_load(f)
+        assert "regime" in data["tags"]
+        assert "options" in data["tags"]
+
+    def test_update_tag_no_duplicate(self, workspace, capsys):
+        """Test that adding an existing tag doesn't duplicate."""
+        from research_system.cli.main import cmd_explore_update
+        import argparse
+
+        self._create_effort(workspace, "my-topic", tags=["options"])
+
+        args = argparse.Namespace(
+            topic="my-topic",
+            status=None,
+            strategy=None,
+            tag="options",
+            v4_workspace=str(workspace.path),
+            workspace=None,
+        )
+        result = cmd_explore_update(args)
+        assert result == 0
+
+        with open(workspace.research_path / "my-topic" / "research.yaml") as f:
+            data = yaml.safe_load(f)
+        assert data["tags"].count("options") == 1
+
+        captured = capsys.readouterr()
+        assert "already present" in captured.out
+
+    def test_update_multiple_fields(self, workspace):
+        """Test updating status and adding strategy at the same time."""
+        from research_system.cli.main import cmd_explore_update
+        import argparse
+
+        self._create_effort(workspace, "my-topic")
+
+        args = argparse.Namespace(
+            topic="my-topic",
+            status="complete",
+            strategy="STRAT-310",
+            tag="quality",
+            v4_workspace=str(workspace.path),
+            workspace=None,
+        )
+        result = cmd_explore_update(args)
+        assert result == 0
+
+        with open(workspace.research_path / "my-topic" / "research.yaml") as f:
+            data = yaml.safe_load(f)
+        assert data["status"] == "complete"
+        assert "STRAT-310" in data["strategies_produced"]
+        assert "quality" in data["tags"]
+
+    def test_error_on_missing_topic(self, workspace):
+        """Test that explore-update errors when topic doesn't exist."""
+        from research_system.cli.main import cmd_explore_update
+        import argparse
+
+        args = argparse.Namespace(
+            topic="nonexistent",
+            status="complete",
+            strategy=None,
+            tag=None,
+            v4_workspace=str(workspace.path),
+            workspace=None,
+        )
+        result = cmd_explore_update(args)
+        assert result == 1
+
+    def test_error_no_update_flags(self, workspace):
+        """Test that explore-update errors when no flags provided."""
+        from research_system.cli.main import cmd_explore_update
+        import argparse
+
+        self._create_effort(workspace, "my-topic")
+
+        args = argparse.Namespace(
+            topic="my-topic",
+            status=None,
+            strategy=None,
+            tag=None,
+            v4_workspace=str(workspace.path),
+            workspace=None,
+        )
+        result = cmd_explore_update(args)
+        assert result == 1
+
+
+# ============================================================================
+# Workspace integration
+# ============================================================================
+
+
+class TestWorkspaceResearchIntegration:
+    """Test workspace changes for research support."""
+
+    def test_research_in_workspace_dirs(self):
+        """Test that 'research' is in WORKSPACE_DIRS."""
+        assert "research" in Workspace.WORKSPACE_DIRS
+
+    def test_init_creates_research_dir(self, tmp_path):
+        """Test that workspace init creates the research directory."""
+        ws = Workspace(tmp_path)
+        ws.init()
+        assert (tmp_path / "research").exists()
+        assert (tmp_path / "research").is_dir()
+
+    def test_research_path_property(self, tmp_path):
+        """Test the research_path property."""
+        ws = Workspace(tmp_path)
+        assert ws.research_path == tmp_path / "research"
+
+    def test_status_includes_research_efforts(self, tmp_path):
+        """Test that status() includes research_efforts count."""
+        ws = Workspace(tmp_path)
+        ws.init()
+        status = ws.status()
+        assert "research_efforts" in status
+        assert status["research_efforts"] == 0
+
+    def test_status_counts_research_efforts(self, tmp_path):
+        """Test that status() correctly counts research efforts."""
+        ws = Workspace(tmp_path)
+        ws.init()
+
+        # Create two research efforts
+        for topic in ["topic-a", "topic-b"]:
+            d = ws.research_path / topic
+            d.mkdir(parents=True)
+            with open(d / "research.yaml", "w") as f:
+                yaml.dump({"topic": topic}, f)
+
+        # Create a directory without research.yaml (should not be counted)
+        (ws.research_path / "not-a-research").mkdir()
+
+        status = ws.status()
+        assert status["research_efforts"] == 2


### PR DESCRIPTION
## Summary
- Adds `research explore-init`, `research explore-list`, `research explore-update` CLI commands
- Each research effort gets a `research/{topic}/research.yaml` (5 fields: topic, title, status, tags, strategies_produced) + `RESEARCH_PLAN.md` template
- `explore-list` prints a formatted table; `--index` flag writes `research/INDEX.md`
- `explore-update` modifies status, appends strategies/tags (deduped)
- Adds `research/` to `WORKSPACE_DIRS`, `research_path` property, research effort count to `summary()`
- 34 new tests, all passing. Zero regressions (9 pre-existing failures on main unchanged)

## Test plan
- [x] 34 unit tests covering slugify, init, list, update, workspace integration
- [x] Full test suite: 683 passed, 0 new failures
- [ ] Manual testing in workspace after merge

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)