### PR TITLE
feat: clean up V4 naming regressions, make CLI primary LLM backend

### DIFF
--- a/research_system/cli/main.py
+++ b/research_system/cli/main.py
@@ -41,22 +41,21 @@ from research_system.core.workspace import (
 from research_system.core.catalog import Catalog
 from research_system.core.data_registry import DataRegistry
 
-# V4 imports
 from research_system.core.v4 import (
-    V4Workspace,
-    get_v4_workspace,
-    V4WorkspaceError,
+    Workspace,
+    get_workspace,
+    WorkspaceError,
     load_config,
     get_default_config,
     validate_config,
 )
 
 
-def get_workspace_from_args(args) -> V4Workspace:
-    """Get V4 workspace from args, checking both global and subparser workspace flags."""
+def get_workspace_from_args(args) -> Workspace:
+    """Get workspace from args, checking both global and subparser workspace flags."""
     # Check subparser-specific flag first, then global flag
-    path = getattr(args, 'v4_workspace', None) or getattr(args, 'workspace', None)
-    return get_v4_workspace(path)
+    path = getattr(args, 'workspace', None)
+    return get_workspace(path)
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -117,7 +116,7 @@ For more information, visit: https://github.com/your-repo/research-system
     # _add_synthesize_parser(subparsers)  # Conflicts with new 'synthesize'
     _add_migrate_parser(subparsers)
 
-    # Add main commands (formerly V4)
+    # Add main commands
     _add_commands(subparsers)
 
     # Add update command
@@ -779,14 +778,14 @@ def _add_migrate_parser(subparsers):
 
 
 # ============================================================================
-# V4 Command Parsers
+# Command Parsers
 # ============================================================================
 
 
 def _add_commands(subparsers):
-    """Add V4-related subcommands.
+    """Add research workflow subcommands.
 
-    V4 commands support the new research workflow:
+    Commands support the research workflow:
     - init: Initialize workspace
     - ingest: Ingest files from inbox with quality scoring
     - verify: Run verification tests (bias detection)
@@ -818,7 +817,7 @@ Strategies meeting minimum thresholds are created in strategies/pending/.
     )
     parser.add_argument(
         "--workspace", "-w",
-        dest="v4_workspace",
+        dest="workspace",
         metavar="PATH",
         help="Path to workspace (default: RESEARCH_WORKSPACE or ~/.research-workspace)"
     )
@@ -858,7 +857,7 @@ Tests include:
     )
     parser.add_argument(
         "--workspace", "-w",
-        dest="v4_workspace",
+        dest="workspace",
         metavar="PATH",
         help="Path to workspace"
     )
@@ -895,7 +894,7 @@ strategy robustness across different market regimes.
     )
     parser.add_argument(
         "--workspace", "-w",
-        dest="v4_workspace",
+        dest="workspace",
         metavar="PATH",
         help="Path to workspace"
     )
@@ -944,7 +943,7 @@ Analyzes validation results to identify:
     )
     parser.add_argument(
         "--workspace", "-w",
-        dest="v4_workspace",
+        dest="workspace",
         metavar="PATH",
         help="Path to workspace"
     )
@@ -982,7 +981,7 @@ Use --quick for fast template-based ideation (no LLM required).
     )
     parser.add_argument(
         "--workspace", "-w",
-        dest="v4_workspace",
+        dest="workspace",
         metavar="PATH",
         help="Path to workspace"
     )
@@ -1023,7 +1022,7 @@ Director:    synthesis-director (integrates all perspectives)
     )
     parser.add_argument(
         "--workspace", "-w",
-        dest="v4_workspace",
+        dest="workspace",
         metavar="PATH",
         help="Path to workspace"
     )
@@ -1104,7 +1103,7 @@ Examples:
     )
     parser.add_argument(
         "--workspace", "-w",
-        dest="v4_workspace",
+        dest="workspace",
         metavar="PATH",
         help="Path to workspace"
     )
@@ -1139,7 +1138,7 @@ Examples:
     )
     parser.add_argument(
         "--workspace", "-w",
-        dest="v4_workspace",
+        dest="workspace",
         metavar="PATH",
         help="Path to workspace"
     )
@@ -1214,7 +1213,7 @@ Examples:
     )
     parser.add_argument(
         "--workspace", "-w",
-        dest="v4_workspace",
+        dest="workspace",
         metavar="PATH",
         help="Path to workspace"
     )
@@ -1237,7 +1236,7 @@ Displays a summary of the workspace including:
     )
     parser.add_argument(
         "--workspace", "-w",
-        dest="v4_workspace",
+        dest="workspace",
         metavar="PATH",
         help="Path to workspace"
     )
@@ -1276,7 +1275,7 @@ Statuses:
     )
     parser.add_argument(
         "--workspace", "-w",
-        dest="v4_workspace",
+        dest="workspace",
         metavar="PATH",
         help="Path to workspace"
     )
@@ -1310,7 +1309,7 @@ Shows all strategy metadata including:
     )
     parser.add_argument(
         "--workspace", "-w",
-        dest="v4_workspace",
+        dest="workspace",
         metavar="PATH",
         help="Path to workspace"
     )
@@ -1338,7 +1337,7 @@ Configuration includes:
     )
     parser.add_argument(
         "--workspace", "-w",
-        dest="v4_workspace",
+        dest="workspace",
         metavar="PATH",
         help="Path to workspace"
     )
@@ -1373,7 +1372,7 @@ Examples:
     )
     parser.add_argument(
         "--workspace", "-w",
-        dest="v4_workspace",
+        dest="workspace",
         metavar="PATH",
         help="Path to workspace"
     )
@@ -1401,7 +1400,7 @@ Examples:
     )
     parser.add_argument(
         "--workspace", "-w",
-        dest="v4_workspace",
+        dest="workspace",
         metavar="PATH",
         help="Path to workspace"
     )
@@ -1441,7 +1440,7 @@ Examples:
     )
     parser.add_argument(
         "--workspace", "-w",
-        dest="v4_workspace",
+        dest="workspace",
         metavar="PATH",
         help="Path to workspace"
     )
@@ -1455,13 +1454,13 @@ Examples:
 def cmd_init(args):
     """Initialize a new workspace."""
     # Always use workspace format
-    return cmd_init_v4(args)
+    return cmd_init_workspace(args)
 
 
-def cmd_init_v4(args):
+def cmd_init_workspace(args):
     """Initialize a new workspace."""
     path = Path(args.path) if args.path else None
-    workspace = get_v4_workspace(path)
+    workspace = get_workspace(path)
 
     if workspace.exists and not args.force:
         print(f"workspace already exists at {workspace.path}")
@@ -1504,7 +1503,7 @@ def cmd_init_v4(args):
 
 
 # ============================================================================
-# V4 Command Implementations
+# Command Implementations
 # ============================================================================
 
 
@@ -1514,13 +1513,13 @@ def cmd_ingest(args):
 
     try:
         workspace.require_initialized()
-    except V4WorkspaceError as e:
+    except WorkspaceError as e:
         print(f"Error: {e}")
         print("Run 'research init' to initialize a workspace.")
         return 1
 
     # Import processor and LLM client
-    from research_system.ingest.v4_processor import V4IngestProcessor
+    from research_system.ingest.strategy_processor import IngestProcessor
     from research_system.llm.client import get_client as get_llm_client
     from research_system.schemas.v4 import IngestionDecision
 
@@ -1532,7 +1531,7 @@ def cmd_ingest(args):
         llm_client = None
 
     # Initialize processor
-    processor = V4IngestProcessor(workspace, config, llm_client)
+    processor = IngestProcessor(workspace, config, llm_client)
 
     # Check options
     dry_run = getattr(args, 'dry_run', False)
@@ -1653,7 +1652,7 @@ def cmd_ingest(args):
 
 def _cmd_verify_all(workspace, args):
     """Verify all pending strategies."""
-    from research_system.validation import V4Verifier, VerificationStatus
+    from research_system.validation import Verifier, VerificationStatus
 
     dry_run = getattr(args, 'dry_run', False)
 
@@ -1666,7 +1665,7 @@ def _cmd_verify_all(workspace, args):
     print(f"\nVerifying {len(strategies)} pending strategy(ies)...")
     print("=" * 50)
 
-    verifier = V4Verifier(workspace)
+    verifier = Verifier(workspace)
     results = {'passed': 0, 'warnings': 0, 'failed': 0}
 
     for i, strat_info in enumerate(strategies, 1):
@@ -1712,7 +1711,7 @@ def _cmd_verify_all(workspace, args):
 
 def _cmd_validate_all(workspace, args):
     """Validate all strategies that have verification results."""
-    from research_system.validation import V4Verifier, V4Validator, VerificationStatus, GateStatus
+    from research_system.validation import Verifier, Validator, VerificationStatus, GateStatus
 
     dry_run = getattr(args, 'dry_run', False)
     results_file = getattr(args, 'results', None)
@@ -1755,8 +1754,8 @@ def _cmd_validate_all(workspace, args):
     print(f"\nValidating {len(strategy_ids)} verified strategy(ies)...")
     print("=" * 50)
 
-    verifier = V4Verifier(workspace)
-    validator = V4Validator(workspace, verifier)
+    verifier = Verifier(workspace)
+    validator = Validator(workspace, verifier)
     results = {'passed': 0, 'failed': 0, 'skipped': 0}
 
     for i, strategy_id in enumerate(sorted(strategy_ids), 1):
@@ -1805,7 +1804,7 @@ def _cmd_validate_all(workspace, args):
 
 def _cmd_learn_all(workspace, args):
     """Extract learnings from all strategies with validation results."""
-    from research_system.validation import V4Learner
+    from research_system.validation import Learner
 
     dry_run = getattr(args, 'dry_run', False)
 
@@ -1831,7 +1830,7 @@ def _cmd_learn_all(workspace, args):
     print(f"\nExtracting learnings from {len(strategy_ids)} strategy(ies)...")
     print("=" * 50)
 
-    learner = V4Learner(workspace)
+    learner = Learner(workspace)
     results = {'extracted': 0, 'skipped': 0}
 
     for i, strategy_id in enumerate(sorted(strategy_ids), 1):
@@ -1875,13 +1874,13 @@ def _cmd_learn_all(workspace, args):
 
 def cmd_verify(args):
     """Run verification tests on a strategy ."""
-    from research_system.validation import V4Verifier, VerificationStatus
+    from research_system.validation import Verifier, VerificationStatus
 
     workspace = get_workspace_from_args(args)
 
     try:
         workspace.require_initialized()
-    except V4WorkspaceError as e:
+    except WorkspaceError as e:
         print(f"Error: {e}")
         print("Run 'research init' to initialize a workspace.")
         return 1
@@ -1911,7 +1910,7 @@ def cmd_verify(args):
     print(f"\nVerifying strategy: {strategy_id}")
     print("=" * 50)
 
-    verifier = V4Verifier(workspace)
+    verifier = Verifier(workspace)
     result = verifier.verify(strategy)
 
     # Display results
@@ -1956,8 +1955,8 @@ def cmd_validate(args):
     import json
     import yaml
     from research_system.validation import (
-        V4Verifier,
-        V4Validator,
+        Verifier,
+        Validator,
         VerificationStatus,
         GateStatus,
     )
@@ -1966,7 +1965,7 @@ def cmd_validate(args):
 
     try:
         workspace.require_initialized()
-    except V4WorkspaceError as e:
+    except WorkspaceError as e:
         print(f"Error: {e}")
         print("Run 'research init' to initialize a workspace.")
         return 1
@@ -1999,7 +1998,7 @@ def cmd_validate(args):
 
     # Step 1: Run verification first
     print("\n[Step 1] Running verification...")
-    verifier = V4Verifier(workspace)
+    verifier = Verifier(workspace)
     verify_result = verifier.verify(strategy)
 
     if verify_result.overall_status == VerificationStatus.FAIL:
@@ -2013,7 +2012,7 @@ def cmd_validate(args):
         print("  PASSED")
 
     # Step 2: Initialize validator
-    validator = V4Validator(workspace, verifier)
+    validator = Validator(workspace, verifier)
 
     # Step 3: Generate backtest config if requested
     if generate_config:
@@ -2106,13 +2105,13 @@ def cmd_validate(args):
 
 def cmd_learn(args):
     """Extract learnings from validation results ."""
-    from research_system.validation import V4Learner
+    from research_system.validation import Learner
 
     workspace = get_workspace_from_args(args)
 
     try:
         workspace.require_initialized()
-    except V4WorkspaceError as e:
+    except WorkspaceError as e:
         print(f"Error: {e}")
         print("Run 'research init' to initialize a workspace.")
         return 1
@@ -2142,7 +2141,7 @@ def cmd_learn(args):
     print("=" * 50)
 
     # Initialize learner and load results
-    learner = V4Learner(workspace)
+    learner = Learner(workspace)
     verification_results, validation_results = learner.load_results(strategy_id)
 
     print(f"\nFound {len(verification_results)} verification result(s)")
@@ -2207,7 +2206,7 @@ def cmd_ideate(args):
 
     try:
         workspace.require_initialized()
-    except V4WorkspaceError as e:
+    except WorkspaceError as e:
         print(f"Error: {e}")
         print("Run 'research init' to initialize a workspace.")
         return 1
@@ -2347,7 +2346,7 @@ def cmd_synthesize(args):
 
     try:
         workspace.require_initialized()
-    except V4WorkspaceError as e:
+    except WorkspaceError as e:
         print(f"Error: {e}")
         print("Run 'research init' to initialize a workspace.")
         return 1
@@ -2364,7 +2363,7 @@ def cmd_synthesize(args):
         print(f"LLM backend: {llm_client.backend.value}")
     except Exception as e:
         print(f"Error: Could not initialize LLM client: {e}")
-        print("Synthesis requires an LLM backend. Set ANTHROPIC_API_KEY or install Claude CLI.")
+        print("Synthesis requires an LLM backend. Install Claude CLI or set ANTHROPIC_API_KEY.")
         return 1
 
     runner = SynthesisRunner(workspace, llm_client)
@@ -2372,7 +2371,7 @@ def cmd_synthesize(args):
 
     if result.offline:
         print("\nNo LLM backend available.")
-        print("Set ANTHROPIC_API_KEY or install Claude CLI.")
+        print("Install Claude CLI or set ANTHROPIC_API_KEY.")
         return 1
 
     if result.errors:
@@ -2406,13 +2405,13 @@ def cmd_synthesize(args):
 
 def cmd_run(args):
     """Run full validation pipeline ."""
-    from research_system.validation.v4_runner import V4Runner
+    from research_system.validation import Runner
 
     workspace = get_workspace_from_args(args)
 
     try:
         workspace.require_initialized()
-    except V4WorkspaceError as e:
+    except WorkspaceError as e:
         print(f"Error: {e}")
         print("Run 'research init' to initialize a workspace.")
         return 1
@@ -2450,7 +2449,7 @@ def cmd_run(args):
         print(f"Note: LLM client not available ({e}). Using templates only.")
 
     # Initialize runner
-    runner = V4Runner(
+    runner = Runner(
         workspace=workspace,
         llm_client=llm_client,
         use_local=use_local,
@@ -2496,7 +2495,7 @@ def cmd_cleanup(args):
 
     try:
         workspace.require_initialized()
-    except V4WorkspaceError as e:
+    except WorkspaceError as e:
         print(f"Error: {e}")
         print("Run 'research init' to initialize a workspace.")
         return 1
@@ -2554,13 +2553,13 @@ def cmd_walkforward(args):
         format_parameter_evolution,
     )
     from research_system.validation.backtest import BacktestExecutor
-    from research_system.codegen.v4_generator import V4CodeGenerator
+    from research_system.codegen import CodeGenerator
 
     workspace = get_workspace_from_args(args)
 
     try:
         workspace.require_initialized()
-    except V4WorkspaceError as e:
+    except WorkspaceError as e:
         print(f"Error: {e}")
         print("Run 'research init' to initialize a workspace.")
         return 1
@@ -2615,7 +2614,7 @@ def cmd_walkforward(args):
         use_local=False,
         timeout=workspace.config.backtest.timeout,
     )
-    code_generator = V4CodeGenerator()
+    code_generator = CodeGenerator()
 
     # Create runner
     runner = WalkForwardRunner(
@@ -2650,7 +2649,7 @@ def cmd_status(args):
 
     try:
         workspace.require_initialized()
-    except V4WorkspaceError as e:
+    except WorkspaceError as e:
         print(f"Error: {e}")
         print("Run 'research init' to initialize a workspace.")
         return 1
@@ -2745,7 +2744,7 @@ def cmd_list(args):
 
     try:
         workspace.require_initialized()
-    except V4WorkspaceError as e:
+    except WorkspaceError as e:
         print(f"Error: {e}")
         print("Run 'research init' to initialize a workspace.")
         return 1
@@ -2814,7 +2813,7 @@ def cmd_show(args):
 
     try:
         workspace.require_initialized()
-    except V4WorkspaceError as e:
+    except WorkspaceError as e:
         print(f"Error: {e}")
         print("Run 'research init' to initialize a workspace.")
         return 1
@@ -2871,7 +2870,7 @@ def _print_strategy_details(strategy: dict) -> None:
             created = created.strftime('%Y-%m-%d %H:%M:%S')
         print(f"Created: {created}")
 
-    # Source (supports both simple and V4 schema formats)
+    # Source (supports both simple and full schema formats)
     source = strategy.get('source', {})
     if source:
         print(f"\n--- Source ---")
@@ -2880,14 +2879,14 @@ def _print_strategy_details(strategy: dict) -> None:
             print(f"Type:      {source['type']}")
         if source.get('author'):
             print(f"Author:    {source['author']}")
-        # V4 format: source.reference, source.credibility
+        # Full format: source.reference, source.credibility
         if source.get('reference'):
             print(f"Reference: {source['reference']}")
         if source.get('url'):
             print(f"URL:       {source['url']}")
         if source.get('track_record'):
             print(f"Track Record: {source['track_record']}")
-        # V4 credibility info (nested)
+        # Credibility info (nested)
         cred = source.get('credibility', {})
         if cred:
             if cred.get('type') and not source.get('type'):
@@ -2903,7 +2902,7 @@ def _print_strategy_details(strategy: dict) -> None:
                 excerpt = excerpt[:200] + "..."
             print(f"Excerpt:   {excerpt}")
 
-    # Hypothesis (supports both simple and V4 schema formats)
+    # Hypothesis (supports both simple and full schema formats)
     hypothesis = strategy.get('hypothesis', {})
     if hypothesis:
         print(f"\n--- Hypothesis ---")
@@ -2920,7 +2919,7 @@ def _print_strategy_details(strategy: dict) -> None:
                 print(f"Expected Sharpe: {exp.get('min', '?')} - {exp.get('max', '?')}")
             else:
                 print(f"Expected Sharpe: {exp}")
-        # V4 format: summary, detail
+        # Full format: summary, detail
         if hypothesis.get('summary') and not hypothesis.get('thesis'):
             print(f"Summary: {hypothesis['summary']}")
         if hypothesis.get('detail'):
@@ -2958,7 +2957,7 @@ def _print_strategy_details(strategy: dict) -> None:
                 else:
                     print(f"Symbols: {', '.join(symbols[:5])} ... (+{len(symbols)-5} more)")
 
-    # Entry (supports both simple and V4 schema formats)
+    # Entry (supports both simple and full schema formats)
     entry = strategy.get('entry', {})
     if entry:
         print(f"\n--- Entry ---")
@@ -2971,7 +2970,7 @@ def _print_strategy_details(strategy: dict) -> None:
                 print(f"Signal {i}: {sig.get('name', 'unnamed')} - {sig.get('condition', '')}")
         if len(signals) > 3:
             print(f"  ... and {len(signals)-3} more signals")
-        # V4 format: technical config
+        # Full format: technical config
         tech = entry.get('technical', {})
         if tech and not signals:
             if tech.get('indicator'):
@@ -2984,7 +2983,7 @@ def _print_strategy_details(strategy: dict) -> None:
             if fund.get('metric'):
                 print(f"Metric: {fund['metric']}")
 
-    # Position (V4 schema)
+    # Position
     position = strategy.get('position', {})
     if position:
         print(f"\n--- Position ---")
@@ -3001,7 +3000,7 @@ def _print_strategy_details(strategy: dict) -> None:
         if sizing and sizing.get('method'):
             print(f"Sizing: {sizing['method']}")
 
-    # Exit (V4 schema: paths, priority)
+    # Exit (paths, priority)
     exit_info = strategy.get('exit', {})
     if exit_info:
         print(f"\n--- Exit ---")
@@ -3042,12 +3041,12 @@ def _print_strategy_details(strategy: dict) -> None:
 
 
 def cmd_config(args):
-    """Show/validate V4 configuration."""
+    """Show/validate configuration."""
     workspace = get_workspace_from_args(args)
 
     try:
         workspace.require_initialized()
-    except V4WorkspaceError as e:
+    except WorkspaceError as e:
         print(f"Error: {e}")
         print("Run 'research init' to initialize a workspace.")
         return 1
@@ -3133,7 +3132,7 @@ def cmd_ingest_process(args):
         from research_system.llm.client import LLMClient, Backend
         llm_client = LLMClient()
         if llm_client.is_offline:
-            print("Note: Running in offline mode (no ANTHROPIC_API_KEY or claude CLI). Extraction will be limited.")
+            print("Note: Running in offline mode (no Claude CLI or ANTHROPIC_API_KEY). Extraction will be limited.")
         elif llm_client.backend == Backend.CLI:
             print("Using Claude CLI backend.")
         elif llm_client.backend == Backend.API:
@@ -4345,7 +4344,7 @@ def cmd_analyze_run(args):
         from research_system.llm.client import LLMClient, Backend
         llm_client = LLMClient()
         if llm_client.is_offline:
-            print("Note: Running in offline mode (no ANTHROPIC_API_KEY or claude CLI)")
+            print("Note: Running in offline mode (no Claude CLI or ANTHROPIC_API_KEY)")
             print("Persona analysis will return prompts only.")
             print()
         elif llm_client.backend == Backend.CLI:
@@ -4548,7 +4547,7 @@ def cmd_ideate_catalog(args):
         from research_system.llm.client import LLMClient, Backend
         llm_client = LLMClient()
         if llm_client.is_offline:
-            print("Note: Running in offline mode (no ANTHROPIC_API_KEY or claude CLI)")
+            print("Note: Running in offline mode (no Claude CLI or ANTHROPIC_API_KEY)")
             print("Ideation will return prompts only, no actual ideas generated.")
             print()
         elif llm_client.backend == Backend.CLI:
@@ -4669,7 +4668,7 @@ def cmd_synthesize_catalog(args):
         from research_system.llm.client import LLMClient, Backend
         llm_client = LLMClient()
         if llm_client.is_offline:
-            print("Note: Running in offline mode (no ANTHROPIC_API_KEY or claude CLI)")
+            print("Note: Running in offline mode (no Claude CLI or ANTHROPIC_API_KEY)")
             print("Synthesis will return prompts only, no actual analysis.")
             print()
         elif llm_client.backend == Backend.CLI:
@@ -5091,7 +5090,7 @@ def cmd_explore_init(args):
 
     try:
         workspace.require_initialized()
-    except V4WorkspaceError as e:
+    except WorkspaceError as e:
         print(f"Error: {e}")
         print("Run 'research init' to initialize a workspace.")
         return 1
@@ -5191,7 +5190,7 @@ def cmd_explore_list(args):
 
     try:
         workspace.require_initialized()
-    except V4WorkspaceError as e:
+    except WorkspaceError as e:
         print(f"Error: {e}")
         print("Run 'research init' to initialize a workspace.")
         return 1
@@ -5274,7 +5273,7 @@ def cmd_explore_update(args):
 
     try:
         workspace.require_initialized()
-    except V4WorkspaceError as e:
+    except WorkspaceError as e:
         print(f"Error: {e}")
         print("Run 'research init' to initialize a workspace.")
         return 1
@@ -5355,7 +5354,7 @@ def main():
     except WorkspaceError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
-    except V4WorkspaceError as e:
+    except WorkspaceError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
     except KeyboardInterrupt:

--- a/research_system/codegen/strategy_generator.py
+++ b/research_system/codegen/strategy_generator.py
@@ -1,6 +1,6 @@
-"""V4 Code Generator - Generate QuantConnect code from V4 strategy documents.
+"""Code Generator - Generate QuantConnect code from strategy documents.
 
-This module provides code generation capabilities for V4 strategies:
+This module provides code generation capabilities for strategies:
 - Template-based generation for common strategy types
 - LLM-based generation for complex/novel strategies
 - Post-processing to fix common QC API issues
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class CodeGenResult:
-    """Result of V4 code generation."""
+    """Result of code generation."""
 
     success: bool
     code: str | None = None
@@ -74,7 +74,7 @@ class CodeCorrectionResult:
 
 
 class CodeGenerator:
-    """Generate QuantConnect Python code for V4 strategies.
+    """Generate QuantConnect Python code for strategies.
 
     Uses a template-first approach:
     1. Check if strategy matches a known template
@@ -749,7 +749,7 @@ def generate_code(
     llm_client=None,
     force_llm: bool = False,
 ) -> CodeGenResult:
-    """Convenience function to generate V4 code.
+    """Convenience function to generate code.
 
     Args:
         strategy: Strategy document

--- a/research_system/core/__init__.py
+++ b/research_system/core/__init__.py
@@ -24,15 +24,15 @@ from .data_registry import (
     DataAvailability,
 )
 
-# V4 system re-exports (for clean access without .v4 subpath)
+# Re-exports from core.v4 (for clean access without .v4 subpath)
 # NOTE: Workspace, WorkspaceError, get_workspace, require_workspace,
 # DEFAULT_WORKSPACE, and WORKSPACE_ENV_VAR are NOT re-exported here under
-# their short names because the legacy workspace already claims those names.
-# Use the V4-prefixed aliases instead, or import from core.v4 directly.
+# their short names because the legacy workspace module already claims those names.
+# Import from core.v4 directly for the current workspace implementation.
 from research_system.core.v4 import (
-    # Config models (no collision)
+    # Config models
     Config,
-    V4Config,
+    V4Config,  # backward-compat alias
     GatesConfig,
     IngestionConfig,
     VerificationConfig,
@@ -41,17 +41,17 @@ from research_system.core.v4 import (
     BacktestConfig as V4BacktestConfig,
     LoggingConfig,
     APIConfig,
-    # Config functions (no collision)
+    # Config functions
     load_config,
     get_default_config,
     validate_config,
     ConfigurationError,
-    # Logging (no collision)
+    # Logging
     setup_logging,
     get_logger,
     LogManager,
-    V4LogManager,
-    # V4-prefixed workspace aliases (safe, no collision with legacy names)
+    V4LogManager,  # backward-compat alias
+    # Workspace (prefixed to avoid collision with legacy workspace module)
     V4Workspace,
     V4WorkspaceError,
     get_v4_workspace,
@@ -59,7 +59,7 @@ from research_system.core.v4 import (
     DEFAULT_V4_WORKSPACE,
 )
 
-# Alias for the V4 workspace env var (avoids collision with legacy WORKSPACE_ENV_VAR)
+# Alias (avoids collision with legacy WORKSPACE_ENV_VAR)
 from research_system.core.v4 import WORKSPACE_ENV_VAR as V4_WORKSPACE_ENV_VAR
 
 __all__ = [
@@ -81,7 +81,7 @@ __all__ = [
     "DataRegistry",
     "DataSource",
     "DataAvailability",
-    # V4 Config
+    # Config
     "Config",
     "V4Config",
     "GatesConfig",
@@ -96,12 +96,12 @@ __all__ = [
     "get_default_config",
     "validate_config",
     "ConfigurationError",
-    # V4 Logging
+    # Logging
     "setup_logging",
     "get_logger",
     "LogManager",
     "V4LogManager",
-    # V4 Workspace (prefixed aliases to avoid legacy collision)
+    # Workspace (prefixed aliases to avoid legacy collision)
     "V4Workspace",
     "V4WorkspaceError",
     "get_v4_workspace",

--- a/research_system/core/v4/__init__.py
+++ b/research_system/core/v4/__init__.py
@@ -1,6 +1,6 @@
-"""V4 Core Module.
+"""Core Module.
 
-This package provides the core components for the V4 research-kit system:
+This package provides the core components for the research-kit system:
 
 - Configuration loading and validation (research-kit.yaml)
 - Workspace management (directories, ID generation)

--- a/research_system/core/v4/config.py
+++ b/research_system/core/v4/config.py
@@ -1,11 +1,10 @@
-"""V4 Configuration System.
+"""Configuration System.
 
-This module provides the configuration system for V4 research-kit, including:
+This module provides the configuration system for research-kit, including:
 - Pydantic models for all configuration sections
 - YAML file loading with default fallbacks
 - Partial config merging
 - Validation with clear error messages
-- Environment variable support for sensitive values
 
 Configuration is loaded from research-kit.yaml files. If no file exists,
 sensible defaults are used. Partial configurations are merged with defaults.
@@ -13,7 +12,6 @@ sensible defaults are used. Partial configurations are merged with defaults.
 
 from __future__ import annotations
 
-import os
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -240,25 +238,12 @@ class LoggingConfig(BaseModel):
 class APIConfig(BaseModel):
     """API configuration.
 
-    API keys can be specified here or via environment variables.
-    Environment variables take precedence.
+    Reserved for future use. LLM access is handled automatically by the
+    LLM client which prefers Claude CLI, then falls back to the Anthropic
+    API (via ANTHROPIC_API_KEY env var), then offline mode.
     """
 
-    anthropic_model: str = Field(
-        "claude-3-5-sonnet-20241022",
-        description="Anthropic model to use for LLM operations",
-    )
-    anthropic_api_key: str | None = Field(
-        None,
-        description="Anthropic API key (can also be set via ANTHROPIC_API_KEY env var)",
-    )
-
-    @model_validator(mode="after")
-    def resolve_env_vars(self) -> "APIConfig":
-        """Resolve API keys from environment variables if not set."""
-        if self.anthropic_api_key is None:
-            self.anthropic_api_key = os.environ.get("ANTHROPIC_API_KEY")
-        return self
+    pass
 
 
 class Config(BaseModel):

--- a/research_system/core/v4/logging.py
+++ b/research_system/core/v4/logging.py
@@ -1,6 +1,6 @@
-"""V4 Logging System.
+"""Logging System.
 
-This module provides logging configuration for the V4 research-kit system.
+This module provides logging configuration for the research-kit system.
 
 Features:
 - Daily rotating log files with TimedRotatingFileHandler

--- a/research_system/core/v4/workspace.py
+++ b/research_system/core/v4/workspace.py
@@ -1,6 +1,6 @@
-"""V4 Workspace Management.
+"""Workspace Management.
 
-This module provides workspace management for the V4 research-kit system.
+This module provides workspace management for the research-kit system.
 A workspace contains all user data separate from the application code:
 
 - inbox/: Files to ingest
@@ -30,7 +30,7 @@ from typing import Any
 
 import yaml
 
-from research_system.core.v4.config import V4Config, get_default_config
+from research_system.core.v4.config import Config, get_default_config
 
 
 # =============================================================================
@@ -56,11 +56,8 @@ COUNTERS_FILE = "counters.json"
 LOCK_FILE = "lock"
 
 # .env template content
-ENV_TEMPLATE = """# Research-Kit V4 Environment Variables
+ENV_TEMPLATE = """# Research-Kit Environment Variables
 # Copy to .env and fill in values
-
-# Anthropic API Key (for LLM calls)
-ANTHROPIC_API_KEY=
 
 # Optional: Override workspace path
 # RESEARCH_WORKSPACE=
@@ -77,7 +74,7 @@ ANTHROPIC_API_KEY=
 
 
 class WorkspaceError(Exception):
-    """Raised when V4 workspace operations fail."""
+    """Raised when workspace operations fail."""
 
     pass
 
@@ -120,7 +117,7 @@ class Workspace:
             path: Workspace path. If None, uses environment variable or default.
         """
         self.path = self._resolve_path(path)
-        self._config: V4Config | None = None
+        self._config: Config | None = None
 
     @staticmethod
     def _resolve_path(path: Path | str | None) -> Path:
@@ -155,11 +152,11 @@ class Workspace:
         return (self.path / CONFIG_FILENAME).exists()
 
     @property
-    def config(self) -> V4Config:
+    def config(self) -> Config:
         """Load workspace configuration.
 
         Returns:
-            V4Config loaded from research-kit.yaml, or defaults if not found.
+            Config loaded from research-kit.yaml, or defaults if not found.
 
         Raises:
             WorkspaceError: If workspace not initialized.
@@ -168,11 +165,11 @@ class Workspace:
             self._config = self._load_config()
         return self._config
 
-    def _load_config(self) -> V4Config:
+    def _load_config(self) -> Config:
         """Load configuration from workspace.
 
         Returns:
-            V4Config loaded and validated.
+            Config loaded and validated.
 
         Raises:
             WorkspaceError: If workspace not initialized.
@@ -193,7 +190,7 @@ class Workspace:
         default_dict = get_default_config().model_dump()
         merged = self._deep_merge(default_dict, data)
 
-        return V4Config(**merged)
+        return Config(**merged)
 
     @staticmethod
     def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
@@ -214,11 +211,11 @@ class Workspace:
                 result[key] = value
         return result
 
-    def _save_config(self, config: V4Config) -> None:
+    def _save_config(self, config: Config) -> None:
         """Save configuration to workspace.
 
         Args:
-            config: V4Config to save.
+            config: Config to save.
         """
         config_file = self.path / CONFIG_FILENAME
         # Use mode='json' to ensure enums and other types are serialized properly

--- a/research_system/llm/client.py
+++ b/research_system/llm/client.py
@@ -65,8 +65,8 @@ class LLMClient:
         Args:
             api_key: Anthropic API key. If not provided, uses ANTHROPIC_API_KEY env var.
             backend: Which backend to use. If None, auto-detects with priority:
-                     1. API (if ANTHROPIC_API_KEY is set)
-                     2. CLI (if claude command is available)
+                     1. CLI (if claude command is available)
+                     2. API (if ANTHROPIC_API_KEY is set)
                      3. Offline (fallback)
         """
         self.api_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
@@ -102,8 +102,13 @@ class LLMClient:
         return Backend.OFFLINE
 
     def _auto_detect_backend(self) -> Backend:
-        """Auto-detect available backend with priority: API > CLI > Offline."""
-        # Try API first
+        """Auto-detect available backend with priority: CLI > API > Offline."""
+        # Try CLI first (preferred — no API key needed)
+        self._cli_path = shutil.which("claude")
+        if self._cli_path:
+            return Backend.CLI
+
+        # Try API
         if self.api_key:
             try:
                 import anthropic
@@ -111,11 +116,6 @@ class LLMClient:
                 return Backend.API
             except ImportError:
                 pass
-
-        # Try CLI
-        self._cli_path = shutil.which("claude")
-        if self._cli_path:
-            return Backend.CLI
 
         # Fallback to offline
         return Backend.OFFLINE

--- a/research_system/optimization/optimizer.py
+++ b/research_system/optimization/optimizer.py
@@ -114,7 +114,7 @@ class ParameterOptimizer:
 
         Args:
             backtest_executor: BacktestExecutor for running backtests
-            code_generator: V4CodeGenerator for generating code
+            code_generator: CodeGenerator for generating code
         """
         self.backtest_executor = backtest_executor
         self.code_generator = code_generator

--- a/research_system/optimization/walk_forward.py
+++ b/research_system/optimization/walk_forward.py
@@ -215,7 +215,7 @@ class WalkForwardRunner:
 
         Args:
             backtest_executor: BacktestExecutor for running backtests
-            code_generator: V4CodeGenerator for generating code
+            code_generator: CodeGenerator for generating code
         """
         self.backtest_executor = backtest_executor
         self.code_generator = code_generator

--- a/research_system/synthesis/runner.py
+++ b/research_system/synthesis/runner.py
@@ -102,7 +102,7 @@ class SynthesisRunner:
         # Check LLM availability
         if self.llm_client is None or self.llm_client.is_offline:
             result.offline = True
-            result.errors.append("No LLM backend available. Set ANTHROPIC_API_KEY or install Claude CLI.")
+            result.errors.append("No LLM backend available. Install Claude CLI or set ANTHROPIC_API_KEY.")
             logger.warning("Ideation skipped: no LLM backend available")
             return result
 
@@ -167,7 +167,7 @@ class SynthesisRunner:
         # Check LLM availability
         if self.llm_client is None or self.llm_client.is_offline:
             result.offline = True
-            result.errors.append("No LLM backend available. Set ANTHROPIC_API_KEY or install Claude CLI.")
+            result.errors.append("No LLM backend available. Install Claude CLI or set ANTHROPIC_API_KEY.")
             return result
 
         # Aggregate workspace context

--- a/research_system/validation/__init__.py
+++ b/research_system/validation/__init__.py
@@ -1,4 +1,4 @@
-"""V4 Validation module for strategy verification and walk-forward testing."""
+"""Validation module for strategy verification and walk-forward testing."""
 
 from research_system.validation.verifier import (
     Verifier,

--- a/research_system/validation/backtest.py
+++ b/research_system/validation/backtest.py
@@ -1,11 +1,9 @@
-"""Backtest execution infrastructure for V4 validation.
+"""Backtest execution infrastructure for validation.
 
 This module provides backtest execution capabilities:
 - BacktestResult: Results from a backtest run
 - BacktestExecutor: Execute backtests via LEAN CLI (local or cloud)
 - WalkForwardResult: Aggregated results from walk-forward validation
-
-Extracted from scripts/validate/full_pipeline.py for V4 integration.
 """
 
 from __future__ import annotations
@@ -189,7 +187,7 @@ class BacktestExecutor:
         """Initialize backtest executor.
 
         Args:
-            workspace_path: Path to the V4 workspace
+            workspace_path: Path to the workspace
             use_local: If True, use local Docker; if False, use QC cloud
             cleanup_on_start: If True, clean up stuck backtests on init
             num_windows: Number of walk-forward windows (1, 2, or 5)
@@ -427,7 +425,7 @@ class BacktestExecutor:
             end_date: End date (YYYY-MM-DD)
             strategy_id: Strategy ID for file naming
             strategy: Original strategy document (for correction context)
-            code_generator: V4CodeGenerator instance with LLM client
+            code_generator: CodeGenerator instance with LLM client
             max_attempts: Maximum number of attempts (including original)
 
         Returns:
@@ -496,7 +494,7 @@ class BacktestExecutor:
             code: Python algorithm code
             strategy_id: Strategy ID
             strategy: Original strategy document
-            code_generator: V4CodeGenerator instance with LLM client
+            code_generator: CodeGenerator instance with LLM client
             windows: List of (start_date, end_date) tuples, or None for defaults
             max_correction_attempts: Maximum correction attempts for first window
 

--- a/research_system/validation/ideator.py
+++ b/research_system/validation/ideator.py
@@ -1,4 +1,4 @@
-"""V4 Strategy Ideator - Generate new strategy ideas.
+"""Strategy Ideator - Generate new strategy ideas.
 
 This module generates new strategy ideas based on:
 - Existing validated strategies
@@ -106,7 +106,7 @@ class Ideator:
         """Initialize ideator.
 
         Args:
-            workspace: V4Workspace instance
+            workspace: Workspace instance
         """
         self.workspace = workspace
 

--- a/research_system/validation/learner.py
+++ b/research_system/validation/learner.py
@@ -1,4 +1,4 @@
-"""V4 Strategy Learner - Extract learnings from validation results.
+"""Strategy Learner - Extract learnings from validation results.
 
 This module extracts insights and learnings from validation results
 to help inform future strategy development.
@@ -59,13 +59,13 @@ class LearningsDocument:
 
 
 class Learner:
-    """Learner for extracting insights from V4 validation results."""
+    """Learner for extracting insights from validation results."""
 
     def __init__(self, workspace):
         """Initialize learner.
 
         Args:
-            workspace: V4Workspace instance
+            workspace: Workspace instance
         """
         self.workspace = workspace
 
@@ -214,7 +214,7 @@ class Learner:
         # Check hypothesis quality
         hypothesis = strategy.get("hypothesis", {})
         if hypothesis:
-            # Look for V4 format (summary) or simple format (thesis)
+            # Look for summary format or simple format (thesis)
             thesis = hypothesis.get("summary") or hypothesis.get("thesis")
             if thesis and len(thesis) > 50:
                 doc.learnings.append(Learning(

--- a/research_system/validation/runner.py
+++ b/research_system/validation/runner.py
@@ -1,7 +1,7 @@
-"""V4 Runner - Orchestrates the complete validation pipeline.
+"""Runner - Orchestrates the complete validation pipeline.
 
 Pipeline steps:
-1. Load V4 strategy YAML
+1. Load strategy YAML
 2. Generate QuantConnect Python code (template or LLM)
 3. Run backtest via LEAN CLI (local or cloud)
 4. Parse results (Sharpe, drawdown, CAGR)
@@ -20,7 +20,7 @@ from typing import Any
 
 import yaml
 
-from research_system.codegen.v4_generator import V4CodeGenerator, V4CodeGenResult
+from research_system.codegen.strategy_generator import CodeGenerator, CodeGenResult
 from research_system.validation.backtest import (
     BacktestExecutor,
     BacktestResult,
@@ -34,12 +34,12 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class RunResult:
-    """Result of a V4 pipeline run."""
+    """Result of a pipeline run."""
 
     strategy_id: str
     success: bool
     determination: str = "PENDING"  # VALIDATED, INVALIDATED, BLOCKED, FAILED
-    code_gen: V4CodeGenResult | None = None
+    code_gen: CodeGenResult | None = None
     backtest: WalkForwardResult | None = None
     gate_results: list[dict[str, Any]] = field(default_factory=list)
     error: str | None = None
@@ -62,13 +62,13 @@ class RunResult:
 
 
 class Runner:
-    """Orchestrates the complete V4 validation pipeline.
+    """Orchestrates the complete validation pipeline.
 
     The runner handles:
     - Strategy loading from workspace
     - Code generation (template or LLM)
     - Backtest execution (local or cloud)
-    - Gate application from V4Config
+    - Gate application from Config
     - Status updates and file management
     - Result persistence
     """
@@ -81,10 +81,10 @@ class Runner:
         num_windows: int = 1,
         reuse_project: bool = True,
     ):
-        """Initialize the V4 runner.
+        """Initialize the runner.
 
         Args:
-            workspace: V4Workspace instance
+            workspace: Workspace instance
             llm_client: Optional LLM client for code generation
             use_local: Use local Docker instead of QC cloud
             num_windows: Number of walk-forward windows (1, 2, or 5)
@@ -96,7 +96,7 @@ class Runner:
         self.num_windows = num_windows
 
         # Initialize code generator
-        self.code_generator = V4CodeGenerator(llm_client)
+        self.code_generator = CodeGenerator(llm_client)
 
         # Load config for gates
         self._config = workspace.config
@@ -132,7 +132,7 @@ class Runner:
         Returns:
             RunResult with pipeline outcome
         """
-        logger.info(f"Running V4 pipeline for {strategy_id}")
+        logger.info(f"Running pipeline for {strategy_id}")
 
         # Step 1: Load strategy
         strategy = self._load_strategy(strategy_id)
@@ -160,15 +160,15 @@ class Runner:
 
         # Step 1b: Run verification check (unless skipped)
         if not skip_verify and not dry_run:
-            from research_system.validation import V4Verifier, VerificationStatus
+            from research_system.validation import Verifier, VerificationStatus
 
             print(f"  Checking verification status...")
-            verifier = V4Verifier(self.workspace)
+            verifier = Verifier(self.workspace)
             verify_result = verifier.verify(strategy)
 
             if verify_result.overall_status == VerificationStatus.FAIL:
                 print(f"    FAILED - {verify_result.failed} verification failures")
-                print(f"    Run 'research v4-verify {strategy_id}' to see details")
+                print(f"    Run 'research verify {strategy_id}' to see details")
                 return RunResult(
                     strategy_id=strategy_id,
                     success=False,
@@ -189,7 +189,7 @@ class Runner:
             existing_code_path = self.workspace.validations_path / strategy_id / "backtest.py"
             if existing_code_path.exists():
                 existing_code = existing_code_path.read_text()
-                code_result = V4CodeGenResult(
+                code_result = CodeGenResult(
                     success=True,
                     code=existing_code,
                     method="existing",
@@ -418,7 +418,7 @@ class Runner:
         self,
         strategy: dict[str, Any],
         force_llm: bool = False,
-    ) -> V4CodeGenResult:
+    ) -> CodeGenResult:
         """Generate backtest code for strategy."""
         return self.code_generator.generate(strategy, force_llm=force_llm)
 
@@ -626,7 +626,7 @@ class Runner:
 
     def _dry_run(self, strategy_id: str, strategy: dict[str, Any]) -> RunResult:
         """Show what would happen without executing."""
-        # V4 schema: tags.hypothesis_type (list), entry.type, hypothesis.summary
+        # Schema: tags.hypothesis_type (list), entry.type, hypothesis.summary
         tags = strategy.get("tags", {})
         hypothesis_type_list = tags.get("hypothesis_type", [])
         strategy_type = ", ".join(hypothesis_type_list) if hypothesis_type_list else "unknown"
@@ -640,8 +640,8 @@ class Runner:
         print(f"  Description: {description[:80]}...")
 
         # Check if template would match
-        from research_system.codegen.templates.v4 import get_template_for_v4_strategy
-        template = get_template_for_v4_strategy(strategy_type, signal_type)
+        from research_system.codegen.templates.v4 import get_template_for_strategy
+        template = get_template_for_strategy(strategy_type, signal_type)
         print(f"  Code generation: {'Template' if template != 'base.py.j2' else 'LLM'}")
         if template != "base.py.j2":
             print(f"    Template: {template}")

--- a/research_system/validation/validator.py
+++ b/research_system/validation/validator.py
@@ -1,4 +1,4 @@
-"""V4 Strategy Validator - Run walk-forward validation on strategies.
+"""Strategy Validator - Run walk-forward validation on strategies.
 
 This module provides walk-forward validation for strategies, including:
 - Pre-validation verification checks
@@ -86,14 +86,14 @@ DEFAULT_GATES = {
 
 
 class Validator:
-    """Validator for V4 strategies."""
+    """Validator for strategies."""
 
     def __init__(self, workspace, verifier=None):
         """Initialize validator.
 
         Args:
-            workspace: V4Workspace instance
-            verifier: Optional V4Verifier instance (created if not provided)
+            workspace: Workspace instance
+            verifier: Optional Verifier instance (created if not provided)
         """
         self.workspace = workspace
         self.verifier = verifier

--- a/research_system/validation/verifier.py
+++ b/research_system/validation/verifier.py
@@ -1,4 +1,4 @@
-"""V4 Strategy Verifier - Run verification tests on strategies.
+"""Strategy Verifier - Run verification tests on strategies.
 
 This module provides verification tests to check strategies for common issues
 before running backtests, including:
@@ -82,7 +82,7 @@ class VerificationResult:
 
 
 class Verifier:
-    """Verifier for V4 strategies."""
+    """Verifier for strategies."""
 
     # Keywords that suggest look-ahead bias
     LOOK_AHEAD_KEYWORDS = [
@@ -100,7 +100,7 @@ class Verifier:
         """Initialize verifier with workspace.
 
         Args:
-            workspace: V4Workspace instance
+            workspace: Workspace instance
         """
         self.workspace = workspace
 

--- a/tests/v4/test_config.py
+++ b/tests/v4/test_config.py
@@ -115,11 +115,11 @@ class TestDefaultConfig:
         assert config.logging.level == "INFO"
         assert "%(asctime)s" in config.logging.format
 
-    def test_default_api_model(self):
-        """Test default API model."""
+    def test_default_api_config(self):
+        """Test default API config exists."""
         config = get_default_config()
 
-        assert config.api.anthropic_model == "claude-3-5-sonnet-20241022"
+        assert config.api is not None
 
 
 # =============================================================================
@@ -524,29 +524,10 @@ class TestValidateConfig:
 class TestEnvironmentVariables:
     """Test environment variable support for API keys."""
 
-    def test_api_key_from_env_var(self, monkeypatch):
-        """Test that API key is read from environment variable."""
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key-123")
-
+    def test_api_config_empty(self):
+        """Test that APIConfig has no fields (reserved for future use)."""
         config = APIConfig()
-
-        assert config.anthropic_api_key == "test-api-key-123"
-
-    def test_explicit_api_key_overrides_env(self, monkeypatch):
-        """Test that explicit API key takes precedence."""
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "env-key")
-
-        config = APIConfig(anthropic_api_key="explicit-key")
-
-        assert config.anthropic_api_key == "explicit-key"
-
-    def test_api_key_none_when_not_set(self, monkeypatch):
-        """Test that API key is None when not set."""
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-
-        config = APIConfig()
-
-        assert config.anthropic_api_key is None
+        assert config is not None
 
 
 # =============================================================================
@@ -611,8 +592,7 @@ logging:
   level: INFO
   format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
-api:
-  anthropic_model: claude-3-5-sonnet-20241022
+api: {}
 """
 
         config_file = tmp_path / "research-kit.yaml"
@@ -631,7 +611,7 @@ api:
         assert "sharpe_above_3" in config.red_flags.hard_reject
         assert "unknown_rationale" in config.red_flags.soft_warning
         assert config.logging.level == "INFO"
-        assert config.api.anthropic_model == "claude-3-5-sonnet-20241022"
+        assert config.api is not None
 
         # Validate config
         errors = validate_config(config)

--- a/tests/v4/test_explore.py
+++ b/tests/v4/test_explore.py
@@ -90,8 +90,7 @@ class TestExploreInit:
         args = argparse.Namespace(
             title="Regime-Conditioned Options",
             tags="options,regime",
-            v4_workspace=str(workspace.path),
-            workspace=None,
+            workspace=str(workspace.path),
         )
         result = cmd_explore_init(args)
         assert result == 0
@@ -109,8 +108,7 @@ class TestExploreInit:
         args = argparse.Namespace(
             title="FX Carry Signal",
             tags="fx,carry",
-            v4_workspace=str(workspace.path),
-            workspace=None,
+            workspace=str(workspace.path),
         )
         cmd_explore_init(args)
 
@@ -132,8 +130,7 @@ class TestExploreInit:
         args = argparse.Namespace(
             title="Volatility Surface",
             tags="",
-            v4_workspace=str(workspace.path),
-            workspace=None,
+            workspace=str(workspace.path),
         )
         cmd_explore_init(args)
 
@@ -157,8 +154,7 @@ class TestExploreInit:
         args = argparse.Namespace(
             title="No Tags Research",
             tags="",
-            v4_workspace=str(workspace.path),
-            workspace=None,
+            workspace=str(workspace.path),
         )
         result = cmd_explore_init(args)
         assert result == 0
@@ -176,8 +172,7 @@ class TestExploreInit:
         args = argparse.Namespace(
             title="Duplicate Topic",
             tags="",
-            v4_workspace=str(workspace.path),
-            workspace=None,
+            workspace=str(workspace.path),
         )
         # Create first
         result = cmd_explore_init(args)
@@ -195,8 +190,7 @@ class TestExploreInit:
         args = argparse.Namespace(
             title="!!!",
             tags="",
-            v4_workspace=str(workspace.path),
-            workspace=None,
+            workspace=str(workspace.path),
         )
         result = cmd_explore_init(args)
         assert result == 1
@@ -231,8 +225,7 @@ class TestExploreList:
 
         args = argparse.Namespace(
             index=False,
-            v4_workspace=str(workspace.path),
-            workspace=None,
+            workspace=str(workspace.path),
         )
         result = cmd_explore_list(args)
         assert result == 0
@@ -252,8 +245,7 @@ class TestExploreList:
 
         args = argparse.Namespace(
             index=False,
-            v4_workspace=str(workspace.path),
-            workspace=None,
+            workspace=str(workspace.path),
         )
         result = cmd_explore_list(args)
         assert result == 0
@@ -274,8 +266,7 @@ class TestExploreList:
 
         args = argparse.Namespace(
             index=False,
-            v4_workspace=str(workspace.path),
-            workspace=None,
+            workspace=str(workspace.path),
         )
         cmd_explore_list(args)
 
@@ -292,8 +283,7 @@ class TestExploreList:
 
         args = argparse.Namespace(
             index=False,
-            v4_workspace=str(workspace.path),
-            workspace=None,
+            workspace=str(workspace.path),
         )
         cmd_explore_list(args)
 
@@ -312,8 +302,7 @@ class TestExploreList:
 
         args = argparse.Namespace(
             index=True,
-            v4_workspace=str(workspace.path),
-            workspace=None,
+            workspace=str(workspace.path),
         )
         result = cmd_explore_list(args)
         assert result == 0
@@ -338,8 +327,7 @@ class TestExploreList:
 
         args = argparse.Namespace(
             index=True,
-            v4_workspace=str(workspace.path),
-            workspace=None,
+            workspace=str(workspace.path),
         )
         cmd_explore_list(args)
 
@@ -357,8 +345,7 @@ class TestExploreList:
 
         args = argparse.Namespace(
             index=False,
-            v4_workspace=str(workspace.path),
-            workspace=None,
+            workspace=str(workspace.path),
         )
         cmd_explore_list(args)
 
@@ -402,8 +389,7 @@ class TestExploreUpdate:
             status="complete",
             strategy=None,
             tag=None,
-            v4_workspace=str(workspace.path),
-            workspace=None,
+            workspace=str(workspace.path),
         )
         result = cmd_explore_update(args)
         assert result == 0
@@ -424,8 +410,7 @@ class TestExploreUpdate:
             status=None,
             strategy="STRAT-200",
             tag=None,
-            v4_workspace=str(workspace.path),
-            workspace=None,
+            workspace=str(workspace.path),
         )
         result = cmd_explore_update(args)
         assert result == 0
@@ -447,8 +432,7 @@ class TestExploreUpdate:
             status=None,
             strategy="STRAT-100",
             tag=None,
-            v4_workspace=str(workspace.path),
-            workspace=None,
+            workspace=str(workspace.path),
         )
         result = cmd_explore_update(args)
         assert result == 0
@@ -472,8 +456,7 @@ class TestExploreUpdate:
             status=None,
             strategy=None,
             tag="regime",
-            v4_workspace=str(workspace.path),
-            workspace=None,
+            workspace=str(workspace.path),
         )
         result = cmd_explore_update(args)
         assert result == 0
@@ -495,8 +478,7 @@ class TestExploreUpdate:
             status=None,
             strategy=None,
             tag="options",
-            v4_workspace=str(workspace.path),
-            workspace=None,
+            workspace=str(workspace.path),
         )
         result = cmd_explore_update(args)
         assert result == 0
@@ -520,8 +502,7 @@ class TestExploreUpdate:
             status="complete",
             strategy="STRAT-310",
             tag="quality",
-            v4_workspace=str(workspace.path),
-            workspace=None,
+            workspace=str(workspace.path),
         )
         result = cmd_explore_update(args)
         assert result == 0
@@ -542,8 +523,7 @@ class TestExploreUpdate:
             status="complete",
             strategy=None,
             tag=None,
-            v4_workspace=str(workspace.path),
-            workspace=None,
+            workspace=str(workspace.path),
         )
         result = cmd_explore_update(args)
         assert result == 1
@@ -560,8 +540,7 @@ class TestExploreUpdate:
             status=None,
             strategy=None,
             tag=None,
-            v4_workspace=str(workspace.path),
-            workspace=None,
+            workspace=str(workspace.path),
         )
         result = cmd_explore_update(args)
         assert result == 1

--- a/tests/v4/test_v4_integration.py
+++ b/tests/v4/test_v4_integration.py
@@ -200,7 +200,7 @@ class TestV4Integration:
         transcript_file.write_text(sample_transcript)
 
         # 3. Check status shows inbox file
-        args = SimpleNamespace(v4_workspace=str(workspace_path))
+        args = SimpleNamespace(workspace=str(workspace_path))
         cmd_status(args)
         captured = capsys.readouterr()
         assert "1 file(s) ready to ingest" in captured.out
@@ -219,7 +219,7 @@ class TestV4Integration:
 
         # 5. List strategies
         args = SimpleNamespace(
-            v4_workspace=str(workspace_path),
+            workspace=str(workspace_path),
             status=None,
             tags=None,
             format="table"
@@ -232,7 +232,7 @@ class TestV4Integration:
         # 6. Show strategy
         args = SimpleNamespace(
             strategy_id="STRAT-001",
-            v4_workspace=str(workspace_path),
+            workspace=str(workspace_path),
             format="text"
         )
         cmd_show(args)
@@ -273,7 +273,7 @@ class TestV4IntegrationErrors:
 
         args = SimpleNamespace(
             strategy_id="STRAT-999",
-            v4_workspace=str(workspace_path),
+            workspace=str(workspace_path),
             format="text"
         )
 
@@ -292,7 +292,7 @@ class TestV4IntegrationErrors:
         ws.init()
 
         args = SimpleNamespace(
-            v4_workspace=str(workspace_path),
+            workspace=str(workspace_path),
             status=None,
             tags=None,
             format="table"

--- a/tests/v4/test_v4_list.py
+++ b/tests/v4/test_v4_list.py
@@ -14,7 +14,7 @@ import yaml
 
 
 @pytest.fixture
-def v4_workspace(tmp_path):
+def workspace(tmp_path):
     """Create an initialized V4 workspace."""
     from research_system.core.v4.workspace import Workspace
 
@@ -24,7 +24,7 @@ def v4_workspace(tmp_path):
 
 
 @pytest.fixture
-def workspace_with_strategies(v4_workspace):
+def workspace_with_strategies(workspace):
     """Create workspace with sample strategies."""
     strategies = [
         {
@@ -66,12 +66,12 @@ def workspace_with_strategies(v4_workspace):
 
     for strat in strategies:
         status = strat.pop("status")
-        filepath = v4_workspace.strategies_path / status / f"{strat['id']}.yaml"
+        filepath = workspace.strategies_path / status / f"{strat['id']}.yaml"
         filepath.parent.mkdir(parents=True, exist_ok=True)
         with open(filepath, "w") as f:
             yaml.dump(strat, f)
 
-    return v4_workspace
+    return workspace
 
 
 # =============================================================================
@@ -82,9 +82,9 @@ def workspace_with_strategies(v4_workspace):
 class TestListStrategies:
     """Tests for Workspace.list_strategies()."""
 
-    def test_list_empty_workspace(self, v4_workspace):
+    def test_list_empty_workspace(self, workspace):
         """Empty workspace returns empty list."""
-        result = v4_workspace.list_strategies()
+        result = workspace.list_strategies()
         assert result == []
 
     def test_list_all_strategies(self, workspace_with_strategies):
@@ -189,13 +189,13 @@ class TestGetStrategy:
 class TestV4ListCLI:
     """Tests for the v4-list CLI command."""
 
-    def test_list_empty_workspace(self, v4_workspace, capsys):
+    def test_list_empty_workspace(self, workspace, capsys):
         """Empty workspace shows appropriate message."""
         from research_system.cli.main import cmd_list
         from types import SimpleNamespace
 
         args = SimpleNamespace(
-            v4_workspace=str(v4_workspace.path),
+            workspace=str(workspace.path),
             status=None,
             tags=None,
             format="table"
@@ -213,7 +213,7 @@ class TestV4ListCLI:
         from types import SimpleNamespace
 
         args = SimpleNamespace(
-            v4_workspace=str(workspace_with_strategies.path),
+            workspace=str(workspace_with_strategies.path),
             status=None,
             tags=None,
             format="table"
@@ -236,7 +236,7 @@ class TestV4ListCLI:
         from types import SimpleNamespace
 
         args = SimpleNamespace(
-            v4_workspace=str(workspace_with_strategies.path),
+            workspace=str(workspace_with_strategies.path),
             status=None,
             tags=None,
             format="json"
@@ -256,7 +256,7 @@ class TestV4ListCLI:
         from types import SimpleNamespace
 
         args = SimpleNamespace(
-            v4_workspace=str(workspace_with_strategies.path),
+            workspace=str(workspace_with_strategies.path),
             status="validated",
             tags=None,
             format="table"
@@ -276,7 +276,7 @@ class TestV4ListCLI:
         from types import SimpleNamespace
 
         args = SimpleNamespace(
-            v4_workspace=str(workspace_with_strategies.path),
+            workspace=str(workspace_with_strategies.path),
             status=None,
             tags="volatility",
             format="table"
@@ -299,7 +299,7 @@ class TestV4ListErrorHandling:
         from types import SimpleNamespace
 
         args = SimpleNamespace(
-            v4_workspace=str(tmp_path / "nonexistent"),
+            workspace=str(tmp_path / "nonexistent"),
             status=None,
             tags=None,
             format="table"
@@ -312,10 +312,10 @@ class TestV4ListErrorHandling:
         assert "Error" in captured.out
         assert "init --v4" in captured.out
 
-    def test_malformed_yaml_graceful(self, v4_workspace, capsys):
+    def test_malformed_yaml_graceful(self, workspace, capsys):
         """Malformed YAML files don't crash the listing."""
         # Create a malformed YAML file
-        malformed = v4_workspace.strategies_path / "pending" / "STRAT-BAD.yaml"
+        malformed = workspace.strategies_path / "pending" / "STRAT-BAD.yaml"
         malformed.parent.mkdir(parents=True, exist_ok=True)
         malformed.write_text("this: is: invalid: yaml: [")
 
@@ -323,7 +323,7 @@ class TestV4ListErrorHandling:
         from types import SimpleNamespace
 
         args = SimpleNamespace(
-            v4_workspace=str(v4_workspace.path),
+            workspace=str(workspace.path),
             status=None,
             tags=None,
             format="table"
@@ -344,7 +344,7 @@ class TestV4ListErrorHandling:
 class TestEdgeCases:
     """Edge case tests."""
 
-    def test_tags_as_list(self, v4_workspace):
+    def test_tags_as_list(self, workspace):
         """Strategies with tags as list (not dict) work."""
         strat = {
             "id": "STRAT-010",
@@ -352,38 +352,38 @@ class TestEdgeCases:
             "created": "2024-01-20T10:00:00Z",
             "tags": ["simple", "test"],  # List instead of dict
         }
-        filepath = v4_workspace.strategies_path / "pending" / "STRAT-010.yaml"
+        filepath = workspace.strategies_path / "pending" / "STRAT-010.yaml"
         filepath.parent.mkdir(parents=True, exist_ok=True)
         with open(filepath, "w") as f:
             yaml.dump(strat, f)
 
-        result = v4_workspace.list_strategies()
+        result = workspace.list_strategies()
         assert len(result) == 1
         assert result[0]["tags"] == ["simple", "test"]
 
-    def test_missing_created_field(self, v4_workspace):
+    def test_missing_created_field(self, workspace):
         """Strategies without created field still list."""
         strat = {
             "id": "STRAT-011",
             "name": "No Date Strategy",
         }
-        filepath = v4_workspace.strategies_path / "pending" / "STRAT-011.yaml"
+        filepath = workspace.strategies_path / "pending" / "STRAT-011.yaml"
         filepath.parent.mkdir(parents=True, exist_ok=True)
         with open(filepath, "w") as f:
             yaml.dump(strat, f)
 
-        result = v4_workspace.list_strategies()
+        result = workspace.list_strategies()
         assert len(result) == 1
         assert result[0]["created"] is None
 
-    def test_very_long_name_truncated(self, v4_workspace, capsys):
+    def test_very_long_name_truncated(self, workspace, capsys):
         """Very long names are truncated in table output."""
         strat = {
             "id": "STRAT-012",
             "name": "A" * 100,  # 100 character name
             "created": "2024-01-20T10:00:00Z",
         }
-        filepath = v4_workspace.strategies_path / "pending" / "STRAT-012.yaml"
+        filepath = workspace.strategies_path / "pending" / "STRAT-012.yaml"
         filepath.parent.mkdir(parents=True, exist_ok=True)
         with open(filepath, "w") as f:
             yaml.dump(strat, f)
@@ -392,7 +392,7 @@ class TestEdgeCases:
         from types import SimpleNamespace
 
         args = SimpleNamespace(
-            v4_workspace=str(v4_workspace.path),
+            workspace=str(workspace.path),
             status=None,
             tags=None,
             format="table"

--- a/tests/v4/test_v4_runner.py
+++ b/tests/v4/test_v4_runner.py
@@ -30,7 +30,7 @@ from research_system.validation.runner import Runner, RunResult
 
 
 @pytest.fixture
-def v4_workspace(tmp_path):
+def workspace(tmp_path):
     """Create an initialized V4 workspace."""
     ws = Workspace(tmp_path)
     ws.init()
@@ -38,7 +38,7 @@ def v4_workspace(tmp_path):
 
 
 @pytest.fixture
-def sample_strategy(v4_workspace):
+def sample_strategy(workspace):
     """Create a sample strategy in the workspace."""
     strategy = {
         "id": "STRAT-001",
@@ -56,7 +56,7 @@ def sample_strategy(v4_workspace):
     }
 
     # Save to pending directory
-    pending_path = v4_workspace.strategies_path / "pending"
+    pending_path = workspace.strategies_path / "pending"
     pending_path.mkdir(parents=True, exist_ok=True)
     strategy_file = pending_path / "STRAT-001.yaml"
     strategy_file.write_text(yaml.dump(strategy))
@@ -65,10 +65,10 @@ def sample_strategy(v4_workspace):
 
 
 @pytest.fixture
-def runner(v4_workspace):
+def runner(workspace):
     """Create a Runner with mocked backtest executor."""
     return Runner(
-        workspace=v4_workspace,
+        workspace=workspace,
         llm_client=None,
         use_local=True,
     )
@@ -214,7 +214,7 @@ class TestGateApplication:
 class TestDryRun:
     """Test dry-run mode doesn't modify files."""
 
-    def test_dry_run_doesnt_move_files(self, runner, sample_strategy, v4_workspace):
+    def test_dry_run_doesnt_move_files(self, runner, sample_strategy, workspace):
         """Test dry-run doesn't move strategy files."""
         # Run in dry-run mode
         result = runner.run("STRAT-001", dry_run=True)
@@ -223,9 +223,9 @@ class TestDryRun:
         assert result.determination == "PENDING"
 
         # Strategy should still be in pending
-        assert (v4_workspace.strategies_path / "pending" / "STRAT-001.yaml").exists()
-        assert not (v4_workspace.strategies_path / "validated" / "STRAT-001.yaml").exists()
-        assert not (v4_workspace.strategies_path / "invalidated" / "STRAT-001.yaml").exists()
+        assert (workspace.strategies_path / "pending" / "STRAT-001.yaml").exists()
+        assert not (workspace.strategies_path / "validated" / "STRAT-001.yaml").exists()
+        assert not (workspace.strategies_path / "invalidated" / "STRAT-001.yaml").exists()
 
     def test_dry_run_shows_strategy_info(self, runner, sample_strategy, capsys):
         """Test dry-run prints strategy information."""
@@ -244,16 +244,16 @@ class TestDryRun:
 class TestResultSaving:
     """Test result saving to validations directory."""
 
-    def test_save_code(self, runner, sample_strategy, v4_workspace):
+    def test_save_code(self, runner, sample_strategy, workspace):
         """Test generated code is saved."""
         code = "# Test code\nclass Test: pass"
         runner._save_code("STRAT-001", code)
 
-        code_file = v4_workspace.validations_path / "STRAT-001" / "backtest.py"
+        code_file = workspace.validations_path / "STRAT-001" / "backtest.py"
         assert code_file.exists()
         assert code_file.read_text() == code
 
-    def test_save_result(self, runner, sample_strategy, v4_workspace):
+    def test_save_result(self, runner, sample_strategy, workspace):
         """Test run result is saved as JSON."""
         wf_result = WalkForwardResult(
             strategy_id="STRAT-001",
@@ -276,7 +276,7 @@ class TestResultSaving:
         runner._save_result("STRAT-001", result)
 
         # Check run_result.json exists
-        result_file = v4_workspace.validations_path / "STRAT-001" / "run_result.json"
+        result_file = workspace.validations_path / "STRAT-001" / "run_result.json"
         assert result_file.exists()
 
         data = json.loads(result_file.read_text())
@@ -284,11 +284,11 @@ class TestResultSaving:
         assert data["determination"] == "VALIDATED"
 
         # Check determination.json exists
-        det_file = v4_workspace.validations_path / "STRAT-001" / "determination.json"
+        det_file = workspace.validations_path / "STRAT-001" / "determination.json"
         assert det_file.exists()
 
         # Check backtest_results.yaml exists
-        bt_file = v4_workspace.validations_path / "STRAT-001" / "backtest_results.yaml"
+        bt_file = workspace.validations_path / "STRAT-001" / "backtest_results.yaml"
         assert bt_file.exists()
 
 
@@ -342,21 +342,21 @@ class TestRunResult:
 class TestStatusUpdates:
     """Test strategy status updates."""
 
-    def test_update_status_moves_file(self, runner, sample_strategy, v4_workspace):
+    def test_update_status_moves_file(self, runner, sample_strategy, workspace):
         """Test status update moves strategy file."""
         runner._update_status("STRAT-001", "validated")
 
         # Should be in validated, not pending
-        assert not (v4_workspace.strategies_path / "pending" / "STRAT-001.yaml").exists()
-        assert (v4_workspace.strategies_path / "validated" / "STRAT-001.yaml").exists()
+        assert not (workspace.strategies_path / "pending" / "STRAT-001.yaml").exists()
+        assert (workspace.strategies_path / "validated" / "STRAT-001.yaml").exists()
 
-    def test_update_status_same_status(self, runner, sample_strategy, v4_workspace):
+    def test_update_status_same_status(self, runner, sample_strategy, workspace):
         """Test status update with same status is no-op."""
         # Strategy is already pending
         runner._update_status("STRAT-001", "pending")
 
         # Should still be in pending
-        assert (v4_workspace.strategies_path / "pending" / "STRAT-001.yaml").exists()
+        assert (workspace.strategies_path / "pending" / "STRAT-001.yaml").exists()
 
 
 # =============================================================================
@@ -368,7 +368,7 @@ class TestBatchProcessing:
     """Test batch processing of strategies."""
 
     @pytest.fixture
-    def multiple_strategies(self, v4_workspace):
+    def multiple_strategies(self, workspace):
         """Create multiple strategies in workspace."""
         strategies = []
         for i in range(3):
@@ -378,7 +378,7 @@ class TestBatchProcessing:
                 "strategy_type": "momentum",
                 "parameters": {"lookback_period": 126, "top_n": 3},
             }
-            strategy_file = v4_workspace.strategies_path / "pending" / f"STRAT-00{i + 1}.yaml"
+            strategy_file = workspace.strategies_path / "pending" / f"STRAT-00{i + 1}.yaml"
             strategy_file.write_text(yaml.dump(strategy))
             strategies.append(strategy)
         return strategies
@@ -414,7 +414,7 @@ class TestForceBlockedRetry:
     """Test --force flag re-runs blocked strategies."""
 
     @pytest.fixture
-    def blocked_strategy(self, v4_workspace):
+    def blocked_strategy(self, workspace):
         """Create a strategy in the blocked directory."""
         strategy = {
             "id": "STRAT-010",
@@ -427,7 +427,7 @@ class TestForceBlockedRetry:
             "status": "blocked",
         }
 
-        blocked_path = v4_workspace.strategies_path / "blocked"
+        blocked_path = workspace.strategies_path / "blocked"
         blocked_path.mkdir(parents=True, exist_ok=True)
         strategy_file = blocked_path / "STRAT-010.yaml"
         strategy_file.write_text(yaml.dump(strategy))
@@ -442,7 +442,7 @@ class TestForceBlockedRetry:
         assert result.determination == "BLOCKED"
         assert "--force" in result.error
 
-    def test_force_moves_blocked_to_pending(self, runner, blocked_strategy, v4_workspace):
+    def test_force_moves_blocked_to_pending(self, runner, blocked_strategy, workspace):
         """Test --force moves strategy from blocked/ to pending/."""
         # Run with force + dry_run to avoid needing full backtest infrastructure
         result = runner.run("STRAT-010", force=True, dry_run=True)
@@ -451,14 +451,14 @@ class TestForceBlockedRetry:
         assert result.determination == "PENDING"
 
         # File should now be in pending, not blocked
-        assert (v4_workspace.strategies_path / "pending" / "STRAT-010.yaml").exists()
-        assert not (v4_workspace.strategies_path / "blocked" / "STRAT-010.yaml").exists()
+        assert (workspace.strategies_path / "pending" / "STRAT-010.yaml").exists()
+        assert not (workspace.strategies_path / "blocked" / "STRAT-010.yaml").exists()
 
-    def test_force_resets_yaml_status(self, runner, blocked_strategy, v4_workspace):
+    def test_force_resets_yaml_status(self, runner, blocked_strategy, workspace):
         """Test --force resets the status field in the YAML to 'pending'."""
         runner.run("STRAT-010", force=True, dry_run=True)
 
-        strategy_file = v4_workspace.strategies_path / "pending" / "STRAT-010.yaml"
+        strategy_file = workspace.strategies_path / "pending" / "STRAT-010.yaml"
         data = yaml.safe_load(strategy_file.read_text())
         assert data["status"] == "pending"
 
@@ -472,7 +472,7 @@ class TestForceBlockedRetry:
         assert "blocked" in captured.out
         assert "pending" in captured.out
 
-    def test_force_on_pending_strategy_is_noop(self, runner, v4_workspace):
+    def test_force_on_pending_strategy_is_noop(self, runner, workspace):
         """Test --force on an already-pending strategy proceeds normally."""
         strategy = {
             "id": "STRAT-011",
@@ -481,7 +481,7 @@ class TestForceBlockedRetry:
             "parameters": {"lookback_period": 126},
             "status": "pending",
         }
-        pending_path = v4_workspace.strategies_path / "pending"
+        pending_path = workspace.strategies_path / "pending"
         pending_path.mkdir(parents=True, exist_ok=True)
         (pending_path / "STRAT-011.yaml").write_text(yaml.dump(strategy))
 
@@ -489,7 +489,7 @@ class TestForceBlockedRetry:
 
         assert result.dry_run
         assert result.determination == "PENDING"
-        assert (v4_workspace.strategies_path / "pending" / "STRAT-011.yaml").exists()
+        assert (workspace.strategies_path / "pending" / "STRAT-011.yaml").exists()
 
 
 # =============================================================================
@@ -501,10 +501,10 @@ class TestWindowConsistencyGate:
     """Test per-window consistency gate for --windows 5 mode."""
 
     @pytest.fixture
-    def runner_5_windows(self, v4_workspace):
+    def runner_5_windows(self, workspace):
         """Create a Runner configured for 5 windows."""
         return Runner(
-            workspace=v4_workspace,
+            workspace=workspace,
             llm_client=None,
             use_local=True,
             num_windows=5,

--- a/tests/v4/test_v4_show.py
+++ b/tests/v4/test_v4_show.py
@@ -15,7 +15,7 @@ import yaml
 
 
 @pytest.fixture
-def v4_workspace(tmp_path):
+def workspace(tmp_path):
     """Create an initialized V4 workspace."""
     from research_system.core.v4.workspace import Workspace
 
@@ -25,7 +25,7 @@ def v4_workspace(tmp_path):
 
 
 @pytest.fixture
-def workspace_with_strategy(v4_workspace):
+def workspace_with_strategy(workspace):
     """Create workspace with a sample strategy."""
     strategy = {
         "id": "STRAT-001",
@@ -74,12 +74,12 @@ def workspace_with_strategy(v4_workspace):
         },
     }
 
-    filepath = v4_workspace.strategies_path / "pending" / "STRAT-001.yaml"
+    filepath = workspace.strategies_path / "pending" / "STRAT-001.yaml"
     filepath.parent.mkdir(parents=True, exist_ok=True)
     with open(filepath, "w") as f:
         yaml.dump(strategy, f)
 
-    return v4_workspace
+    return workspace
 
 
 # =============================================================================
@@ -96,7 +96,7 @@ class TestV4ShowTextFormat:
 
         args = SimpleNamespace(
             strategy_id="STRAT-001",
-            v4_workspace=str(workspace_with_strategy.path),
+            workspace=str(workspace_with_strategy.path),
             format="text"
         )
 
@@ -114,7 +114,7 @@ class TestV4ShowTextFormat:
 
         args = SimpleNamespace(
             strategy_id="STRAT-001",
-            v4_workspace=str(workspace_with_strategy.path),
+            workspace=str(workspace_with_strategy.path),
             format="text"
         )
 
@@ -131,7 +131,7 @@ class TestV4ShowTextFormat:
 
         args = SimpleNamespace(
             strategy_id="STRAT-001",
-            v4_workspace=str(workspace_with_strategy.path),
+            workspace=str(workspace_with_strategy.path),
             format="text"
         )
 
@@ -148,7 +148,7 @@ class TestV4ShowTextFormat:
 
         args = SimpleNamespace(
             strategy_id="STRAT-001",
-            v4_workspace=str(workspace_with_strategy.path),
+            workspace=str(workspace_with_strategy.path),
             format="text"
         )
 
@@ -164,7 +164,7 @@ class TestV4ShowTextFormat:
 
         args = SimpleNamespace(
             strategy_id="STRAT-001",
-            v4_workspace=str(workspace_with_strategy.path),
+            workspace=str(workspace_with_strategy.path),
             format="text"
         )
 
@@ -180,7 +180,7 @@ class TestV4ShowTextFormat:
 
         args = SimpleNamespace(
             strategy_id="STRAT-001",
-            v4_workspace=str(workspace_with_strategy.path),
+            workspace=str(workspace_with_strategy.path),
             format="text"
         )
 
@@ -205,7 +205,7 @@ class TestV4ShowYamlFormat:
 
         args = SimpleNamespace(
             strategy_id="STRAT-001",
-            v4_workspace=str(workspace_with_strategy.path),
+            workspace=str(workspace_with_strategy.path),
             format="yaml"
         )
 
@@ -223,7 +223,7 @@ class TestV4ShowYamlFormat:
 
         args = SimpleNamespace(
             strategy_id="STRAT-001",
-            v4_workspace=str(workspace_with_strategy.path),
+            workspace=str(workspace_with_strategy.path),
             format="yaml"
         )
 
@@ -249,7 +249,7 @@ class TestV4ShowJsonFormat:
 
         args = SimpleNamespace(
             strategy_id="STRAT-001",
-            v4_workspace=str(workspace_with_strategy.path),
+            workspace=str(workspace_with_strategy.path),
             format="json"
         )
 
@@ -267,7 +267,7 @@ class TestV4ShowJsonFormat:
 
         args = SimpleNamespace(
             strategy_id="STRAT-001",
-            v4_workspace=str(workspace_with_strategy.path),
+            workspace=str(workspace_with_strategy.path),
             format="json"
         )
 
@@ -287,13 +287,13 @@ class TestV4ShowJsonFormat:
 class TestV4ShowErrors:
     """Tests for error handling."""
 
-    def test_strategy_not_found(self, v4_workspace, capsys):
+    def test_strategy_not_found(self, workspace, capsys):
         """Shows error for non-existent strategy."""
         from research_system.cli.main import cmd_show
 
         args = SimpleNamespace(
             strategy_id="STRAT-999",
-            v4_workspace=str(v4_workspace.path),
+            workspace=str(workspace.path),
             format="text"
         )
 
@@ -310,7 +310,7 @@ class TestV4ShowErrors:
 
         args = SimpleNamespace(
             strategy_id="STRAT-001",
-            v4_workspace=str(tmp_path / "nonexistent"),
+            workspace=str(tmp_path / "nonexistent"),
             format="text"
         )
 
@@ -330,13 +330,13 @@ class TestV4ShowErrors:
 class TestV4ShowEdgeCases:
     """Edge case tests."""
 
-    def test_minimal_strategy(self, v4_workspace, capsys):
+    def test_minimal_strategy(self, workspace, capsys):
         """Shows minimal strategy with only required fields."""
         strategy = {
             "id": "STRAT-002",
             "name": "Minimal Strategy",
         }
-        filepath = v4_workspace.strategies_path / "pending" / "STRAT-002.yaml"
+        filepath = workspace.strategies_path / "pending" / "STRAT-002.yaml"
         filepath.parent.mkdir(parents=True, exist_ok=True)
         with open(filepath, "w") as f:
             yaml.dump(strategy, f)
@@ -345,7 +345,7 @@ class TestV4ShowEdgeCases:
 
         args = SimpleNamespace(
             strategy_id="STRAT-002",
-            v4_workspace=str(v4_workspace.path),
+            workspace=str(workspace.path),
             format="text"
         )
 
@@ -356,13 +356,13 @@ class TestV4ShowEdgeCases:
         assert "STRAT-002" in captured.out
         assert "Minimal Strategy" in captured.out
 
-    def test_strategy_in_validated(self, v4_workspace, capsys):
+    def test_strategy_in_validated(self, workspace, capsys):
         """Can show strategy from validated directory."""
         strategy = {
             "id": "STRAT-003",
             "name": "Validated Strategy",
         }
-        filepath = v4_workspace.strategies_path / "validated" / "STRAT-003.yaml"
+        filepath = workspace.strategies_path / "validated" / "STRAT-003.yaml"
         filepath.parent.mkdir(parents=True, exist_ok=True)
         with open(filepath, "w") as f:
             yaml.dump(strategy, f)
@@ -371,7 +371,7 @@ class TestV4ShowEdgeCases:
 
         args = SimpleNamespace(
             strategy_id="STRAT-003",
-            v4_workspace=str(v4_workspace.path),
+            workspace=str(workspace.path),
             format="text"
         )
 
@@ -382,7 +382,7 @@ class TestV4ShowEdgeCases:
         assert "STRAT-003" in captured.out
         assert "validated" in captured.out
 
-    def test_strategy_with_many_symbols(self, v4_workspace, capsys):
+    def test_strategy_with_many_symbols(self, workspace, capsys):
         """Truncates display when many symbols."""
         strategy = {
             "id": "STRAT-004",
@@ -392,7 +392,7 @@ class TestV4ShowEdgeCases:
                 "symbols": [f"SYM{i}" for i in range(20)],
             },
         }
-        filepath = v4_workspace.strategies_path / "pending" / "STRAT-004.yaml"
+        filepath = workspace.strategies_path / "pending" / "STRAT-004.yaml"
         filepath.parent.mkdir(parents=True, exist_ok=True)
         with open(filepath, "w") as f:
             yaml.dump(strategy, f)
@@ -401,7 +401,7 @@ class TestV4ShowEdgeCases:
 
         args = SimpleNamespace(
             strategy_id="STRAT-004",
-            v4_workspace=str(v4_workspace.path),
+            workspace=str(workspace.path),
             format="text"
         )
 

--- a/tests/v4/test_v4_status.py
+++ b/tests/v4/test_v4_status.py
@@ -14,7 +14,7 @@ import yaml
 
 
 @pytest.fixture
-def v4_workspace(tmp_path):
+def workspace(tmp_path):
     """Create an initialized V4 workspace."""
     from research_system.core.v4.workspace import Workspace
 
@@ -24,7 +24,7 @@ def v4_workspace(tmp_path):
 
 
 @pytest.fixture
-def workspace_with_content(v4_workspace):
+def workspace_with_content(workspace):
     """Create workspace with strategies and inbox files."""
     # Create strategies in various states
     strategies = [
@@ -35,22 +35,22 @@ def workspace_with_content(v4_workspace):
 
     # Pending strategies
     for s in strategies[:2]:
-        filepath = v4_workspace.strategies_path / "pending" / f"{s['id']}.yaml"
+        filepath = workspace.strategies_path / "pending" / f"{s['id']}.yaml"
         filepath.parent.mkdir(parents=True, exist_ok=True)
         with open(filepath, "w") as f:
             yaml.dump(s, f)
 
     # Validated strategy
-    filepath = v4_workspace.strategies_path / "validated" / f"{strategies[2]['id']}.yaml"
+    filepath = workspace.strategies_path / "validated" / f"{strategies[2]['id']}.yaml"
     filepath.parent.mkdir(parents=True, exist_ok=True)
     with open(filepath, "w") as f:
         yaml.dump(strategies[2], f)
 
     # Add inbox files
-    (v4_workspace.inbox_path / "doc1.txt").write_text("Strategy document 1")
-    (v4_workspace.inbox_path / "doc2.txt").write_text("Strategy document 2")
+    (workspace.inbox_path / "doc1.txt").write_text("Strategy document 1")
+    (workspace.inbox_path / "doc2.txt").write_text("Strategy document 2")
 
-    return v4_workspace
+    return workspace
 
 
 # =============================================================================
@@ -61,12 +61,12 @@ def workspace_with_content(v4_workspace):
 class TestV4StatusBasic:
     """Tests for basic status output."""
 
-    def test_status_empty_workspace(self, v4_workspace, capsys):
+    def test_status_empty_workspace(self, workspace, capsys):
         """Shows status for empty workspace."""
         from research_system.cli.main import cmd_status
 
         args = SimpleNamespace(
-            v4_workspace=str(v4_workspace.path)
+            workspace=str(workspace.path)
         )
 
         result = cmd_status(args)
@@ -74,7 +74,7 @@ class TestV4StatusBasic:
 
         captured = capsys.readouterr()
         assert "Research-Kit Workspace Status" in captured.out
-        assert str(v4_workspace.path) in captured.out
+        assert str(workspace.path) in captured.out
         assert "No strategies yet" in captured.out
 
     def test_status_with_content(self, workspace_with_content, capsys):
@@ -82,7 +82,7 @@ class TestV4StatusBasic:
         from research_system.cli.main import cmd_status
 
         args = SimpleNamespace(
-            v4_workspace=str(workspace_with_content.path)
+            workspace=str(workspace_with_content.path)
         )
 
         result = cmd_status(args)
@@ -94,18 +94,18 @@ class TestV4StatusBasic:
         assert "2" in captured.out  # 2 pending
         assert "1" in captured.out  # 1 validated
 
-    def test_status_shows_workspace_path(self, v4_workspace, capsys):
+    def test_status_shows_workspace_path(self, workspace, capsys):
         """Shows workspace path in output."""
         from research_system.cli.main import cmd_status
 
         args = SimpleNamespace(
-            v4_workspace=str(v4_workspace.path)
+            workspace=str(workspace.path)
         )
 
         cmd_status(args)
 
         captured = capsys.readouterr()
-        assert str(v4_workspace.path) in captured.out
+        assert str(workspace.path) in captured.out
 
 
 # =============================================================================
@@ -121,7 +121,7 @@ class TestV4StatusCounts:
         from research_system.cli.main import cmd_status
 
         args = SimpleNamespace(
-            v4_workspace=str(workspace_with_content.path)
+            workspace=str(workspace_with_content.path)
         )
 
         cmd_status(args)
@@ -137,7 +137,7 @@ class TestV4StatusCounts:
         from research_system.cli.main import cmd_status
 
         args = SimpleNamespace(
-            v4_workspace=str(workspace_with_content.path)
+            workspace=str(workspace_with_content.path)
         )
 
         cmd_status(args)
@@ -155,12 +155,12 @@ class TestV4StatusCounts:
 class TestV4StatusInbox:
     """Tests for inbox status."""
 
-    def test_empty_inbox_message(self, v4_workspace, capsys):
+    def test_empty_inbox_message(self, workspace, capsys):
         """Shows empty inbox message."""
         from research_system.cli.main import cmd_status
 
         args = SimpleNamespace(
-            v4_workspace=str(v4_workspace.path)
+            workspace=str(workspace.path)
         )
 
         cmd_status(args)
@@ -173,7 +173,7 @@ class TestV4StatusInbox:
         from research_system.cli.main import cmd_status
 
         args = SimpleNamespace(
-            v4_workspace=str(workspace_with_content.path)
+            workspace=str(workspace_with_content.path)
         )
 
         cmd_status(args)
@@ -190,12 +190,12 @@ class TestV4StatusInbox:
 class TestV4StatusCounters:
     """Tests for ID counter display."""
 
-    def test_shows_next_ids(self, v4_workspace, capsys):
+    def test_shows_next_ids(self, workspace, capsys):
         """Shows next ID numbers."""
         from research_system.cli.main import cmd_status
 
         args = SimpleNamespace(
-            v4_workspace=str(v4_workspace.path)
+            workspace=str(workspace.path)
         )
 
         cmd_status(args)
@@ -204,16 +204,16 @@ class TestV4StatusCounters:
         assert "Next strategy: STRAT-001" in captured.out
         assert "Next idea:" in captured.out
 
-    def test_counter_increments(self, v4_workspace, capsys):
+    def test_counter_increments(self, workspace, capsys):
         """Counter increments are reflected."""
         # Use some IDs
-        v4_workspace.next_strategy_id()
-        v4_workspace.next_strategy_id()
+        workspace.next_strategy_id()
+        workspace.next_strategy_id()
 
         from research_system.cli.main import cmd_status
 
         args = SimpleNamespace(
-            v4_workspace=str(v4_workspace.path)
+            workspace=str(workspace.path)
         )
 
         cmd_status(args)
@@ -230,12 +230,12 @@ class TestV4StatusCounters:
 class TestV4StatusRecent:
     """Tests for recent strategies section."""
 
-    def test_no_recent_when_empty(self, v4_workspace, capsys):
+    def test_no_recent_when_empty(self, workspace, capsys):
         """No recent section when no strategies."""
         from research_system.cli.main import cmd_status
 
         args = SimpleNamespace(
-            v4_workspace=str(v4_workspace.path)
+            workspace=str(workspace.path)
         )
 
         cmd_status(args)
@@ -248,7 +248,7 @@ class TestV4StatusRecent:
         from research_system.cli.main import cmd_status
 
         args = SimpleNamespace(
-            v4_workspace=str(workspace_with_content.path)
+            workspace=str(workspace_with_content.path)
         )
 
         cmd_status(args)
@@ -271,7 +271,7 @@ class TestV4StatusActions:
         from research_system.cli.main import cmd_status
 
         args = SimpleNamespace(
-            v4_workspace=str(workspace_with_content.path)
+            workspace=str(workspace_with_content.path)
         )
 
         cmd_status(args)
@@ -279,12 +279,12 @@ class TestV4StatusActions:
         captured = capsys.readouterr()
         assert "ingest" in captured.out
 
-    def test_suggests_adding_to_inbox_when_empty(self, v4_workspace, capsys):
+    def test_suggests_adding_to_inbox_when_empty(self, workspace, capsys):
         """Suggests adding docs when empty workspace."""
         from research_system.cli.main import cmd_status
 
         args = SimpleNamespace(
-            v4_workspace=str(v4_workspace.path)
+            workspace=str(workspace.path)
         )
 
         cmd_status(args)
@@ -306,7 +306,7 @@ class TestV4StatusErrors:
         from research_system.cli.main import cmd_status
 
         args = SimpleNamespace(
-            v4_workspace=str(tmp_path / "nonexistent")
+            workspace=str(tmp_path / "nonexistent")
         )
 
         result = cmd_status(args)

--- a/tests/v4/test_workspace.py
+++ b/tests/v4/test_workspace.py
@@ -72,7 +72,6 @@ class TestWorkspaceInit:
         assert env_template.exists()
 
         content = env_template.read_text()
-        assert "ANTHROPIC_API_KEY" in content
         assert "RESEARCH_WORKSPACE" in content
         assert "QC_USER_ID" in content
         assert "QC_API_TOKEN" in content


### PR DESCRIPTION
## Summary
- **Remove V4 prefix** from all public-facing class names, docstrings, CLI arg names (`v4_workspace` → `workspace`), and comments across 18 source files. These regressed after the original cleanup PR #191 via subsequent PRs.
- **Make Claude CLI the primary LLM backend** by reordering `_auto_detect_backend()` priority from `API > CLI > Offline` to `CLI > API > Offline`. CLI requires no API key and is already available in our workflow.
- **Remove dead `APIConfig` fields** (`anthropic_api_key`, `anthropic_model`) that were never consumed by the LLM client. Also removes the `ANTHROPIC_API_KEY` line from the `.env` template.
- **Fix `cmd_ingest` import** that was importing the legacy `IngestProcessor` (2 args) instead of the strategy `IngestProcessor` (3 args).
- **Update all error messages** to mention CLI first, API key second.

Closes #221
Closes #222

## Test plan
- [x] All 647 tests pass (excluding 10 pre-existing failures in unit tests unrelated to these changes)
- [ ] Manual: `research ingest` works with CLI backend
- [ ] Manual: `research status` shows correct workspace info

🤖 Generated with [Claude Code](https://claude.com/claude-code)