### PR TITLE
feat: add --start-date and --end-date CLI args to research run

### DIFF
--- a/research_system/cli/main.py
+++ b/research_system/cli/main.py
@@ -1097,6 +1097,18 @@ Examples:
         help="Number of walk-forward windows: 1 (single period), 2 (IS/OOS, default), or 5 (thorough). Default: 2"
     )
     parser.add_argument(
+        "--start-date",
+        type=str,
+        default=None,
+        help="Custom start date (YYYY-MM-DD). Overrides --windows with a single custom window. Requires --end-date."
+    )
+    parser.add_argument(
+        "--end-date",
+        type=str,
+        default=None,
+        help="Custom end date (YYYY-MM-DD). Overrides --windows with a single custom window. Requires --start-date."
+    )
+    parser.add_argument(
         "--no-reuse-project",
         action="store_true",
         help="Create a new QC cloud project per backtest (legacy mode). Default reuses a single project to avoid 100/day limit."
@@ -2427,6 +2439,24 @@ def cmd_run(args):
     num_windows = getattr(args, 'windows', 1)
     no_reuse = getattr(args, 'no_reuse_project', False)
     reuse_project = not no_reuse
+    start_date = getattr(args, 'start_date', None)
+    end_date = getattr(args, 'end_date', None)
+
+    # Validate custom date range
+    custom_windows = None
+    if start_date or end_date:
+        if not (start_date and end_date):
+            print("Error: --start-date and --end-date must both be provided")
+            return 1
+        import re as _re
+        date_pattern = r"^\d{4}-\d{2}-\d{2}$"
+        if not _re.match(date_pattern, start_date) or not _re.match(date_pattern, end_date):
+            print("Error: Dates must be in YYYY-MM-DD format")
+            return 1
+        if start_date >= end_date:
+            print("Error: --start-date must be before --end-date")
+            return 1
+        custom_windows = [(start_date, end_date)]
 
     if not strategy_id and not run_all:
         print("Error: Strategy ID required or use --all")
@@ -2455,6 +2485,7 @@ def cmd_run(args):
         use_local=use_local,
         num_windows=num_windows,
         reuse_project=reuse_project,
+        custom_windows=custom_windows,
     )
 
     print("\n" + "=" * 60)
@@ -2463,7 +2494,10 @@ def cmd_run(args):
     print(f"\nBacktest mode: {'Local Docker' if use_local else 'QC Cloud'}")
     if not use_local:
         print(f"Project mode: {'reuse single project' if reuse_project else 'new project per backtest'}")
-    print(f"Walk-forward windows: {num_windows}")
+    if custom_windows:
+        print(f"Custom window: {custom_windows[0][0]} to {custom_windows[0][1]}")
+    else:
+        print(f"Walk-forward windows: {num_windows}")
     if dry_run:
         print("[DRY RUN] No backtests will be executed")
     print()

--- a/research_system/validation/backtest.py
+++ b/research_system/validation/backtest.py
@@ -183,6 +183,7 @@ class BacktestExecutor:
         num_windows: int = 1,
         timeout: int = 600,
         reuse_project: bool = True,
+        custom_windows: list[tuple[str, str]] | None = None,
     ):
         """Initialize backtest executor.
 
@@ -194,6 +195,8 @@ class BacktestExecutor:
             timeout: Backtest execution timeout in seconds (default: 600)
             reuse_project: If True, reuse a single QC cloud project to avoid
                 100/day project creation limit. Only applies to cloud mode.
+            custom_windows: Optional list of (start_date, end_date) tuples
+                that override preset window selection. Use with --start-date/--end-date CLI args.
         """
         self.workspace_path = Path(workspace_path)
         self.validations_path = self.workspace_path / "validations"
@@ -205,8 +208,10 @@ class BacktestExecutor:
         # Fixed project directory for reuse mode
         self._runner_project_dir = self.validations_path / "_runner"
 
-        # Select windows based on num_windows
-        if num_windows >= 5:
+        # Select windows: custom overrides presets
+        if custom_windows:
+            self.windows = custom_windows
+        elif num_windows >= 5:
             self.windows = self.ALL_WINDOWS
         elif num_windows == 1:
             self.windows = self.ONE_WINDOW
@@ -743,33 +748,45 @@ class BacktestExecutor:
         return self._parse_lean_output(result.stdout, result.stderr, result.returncode)
 
     def _inject_dates(self, code: str, start_date: str, end_date: str) -> str:
-        """Inject start/end dates into algorithm code."""
+        """Inject start/end dates into algorithm code.
+
+        First tries to replace existing set_start_date/set_end_date calls.
+        If none exist, inserts them at the top of initialize().
+        """
         start_parts = start_date.split("-")
         end_parts = end_date.split("-")
 
-        # Replace PascalCase
-        code = re.sub(
-            r"self\.SetStartDate\([^)]+\)",
-            f"self.SetStartDate({start_parts[0]}, {int(start_parts[1])}, {int(start_parts[2])})",
-            code,
-        )
-        code = re.sub(
-            r"self\.SetEndDate\([^)]+\)",
-            f"self.SetEndDate({end_parts[0]}, {int(end_parts[1])}, {int(end_parts[2])})",
-            code,
-        )
+        start_call = f"self.set_start_date({start_parts[0]}, {int(start_parts[1])}, {int(start_parts[2])})"
+        end_call = f"self.set_end_date({end_parts[0]}, {int(end_parts[1])}, {int(end_parts[2])})"
 
-        # Replace snake_case
-        code = re.sub(
-            r"self\.set_start_date\([^)]+\)",
-            f"self.set_start_date({start_parts[0]}, {int(start_parts[1])}, {int(start_parts[2])})",
-            code,
-        )
-        code = re.sub(
-            r"self\.set_end_date\([^)]+\)",
-            f"self.set_end_date({end_parts[0]}, {int(end_parts[1])}, {int(end_parts[2])})",
-            code,
-        )
+        has_start = bool(re.search(r"self\.[Ss]et_?[Ss]tart_?[Dd]ate\(", code))
+        has_end = bool(re.search(r"self\.[Ss]et_?[Ee]nd_?[Dd]ate\(", code))
+
+        if has_start:
+            # Replace existing PascalCase or snake_case start date calls
+            code = re.sub(r"self\.SetStartDate\([^)]+\)", start_call, code)
+            code = re.sub(r"self\.set_start_date\([^)]+\)", start_call, code)
+
+        if has_end:
+            # Replace existing PascalCase or snake_case end date calls
+            code = re.sub(r"self\.SetEndDate\([^)]+\)", end_call, code)
+            code = re.sub(r"self\.set_end_date\([^)]+\)", end_call, code)
+
+        if not has_start or not has_end:
+            # Insert missing date calls at the top of initialize()
+            inject_lines = ""
+            if not has_start:
+                inject_lines += f"        {start_call}\n"
+            if not has_end:
+                inject_lines += f"        {end_call}\n"
+
+            # Match "def initialize(self):" or "def Initialize(self):" and insert after it
+            pattern = r"(def [Ii]nitialize\(self\):[ \t]*\n)"
+            match = re.search(pattern, code)
+            if match:
+                code = code[:match.end()] + inject_lines + code[match.end():]
+            else:
+                logger.warning("Could not find initialize() method to inject dates")
 
         return code
 

--- a/research_system/validation/runner.py
+++ b/research_system/validation/runner.py
@@ -80,6 +80,7 @@ class Runner:
         use_local: bool = False,
         num_windows: int = 1,
         reuse_project: bool = True,
+        custom_windows: list[tuple[str, str]] | None = None,
     ):
         """Initialize the runner.
 
@@ -89,6 +90,7 @@ class Runner:
             use_local: Use local Docker instead of QC cloud
             num_windows: Number of walk-forward windows (1, 2, or 5)
             reuse_project: Reuse a single QC cloud project (avoids 100/day limit)
+            custom_windows: Optional list of (start_date, end_date) tuples to override presets
         """
         self.workspace = workspace
         self.llm_client = llm_client
@@ -109,6 +111,7 @@ class Runner:
             num_windows=num_windows,
             timeout=self._config.backtest.timeout,
             reuse_project=reuse_project,
+            custom_windows=custom_windows,
         )
 
     def run(


### PR DESCRIPTION
## Summary
- Adds `--start-date YYYY-MM-DD` and `--end-date YYYY-MM-DD` to `research run`
- When both provided, overrides `--windows` with a single custom window
- Validates: both required together, YYYY-MM-DD format, start < end
- Threaded through Runner → BacktestExecutor via `custom_windows` parameter

Closes #227

## Test plan
- [ ] `research run --help` shows new args
- [ ] `research run STRAT-XXX --start-date 2015-01-01 --end-date 2020-12-31` creates correct window
- [ ] Error on `--start-date` without `--end-date`
- [ ] Error on invalid date format
- [ ] All 44 existing CLI tests pass